### PR TITLE
fix: *-firebase-*.json 노출 방지 (.gitignore 추가)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,6 +242,10 @@ yarn-error.log*
 .env*.local
 .firebase.env
 
+# Firebase service account key files
+*-firebase-*.json
+serviceAccountKey.json
+
 # vercel
 .vercel
 


### PR DESCRIPTION
**변경 요약**
- Firebase 서비스 계정 키 파일(*-firebase-*.json, serviceAccountKey.json)이 .gitignore에 누락되어 실수로 커밋·푸시될 경우 자격증명이 GitHub에 노출되는 문제 수정

보안 문제로 긴급 반영