### PR TITLE
[codex] Implement admin stage word CRUD

### DIFF
--- a/backend/src/main/java/com/tokki/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tokki/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import com.tokki.security.RestAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -64,6 +65,9 @@ public class SecurityConfig {
                                 "/ws/**",
                                 "/actuator/health"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/stages/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/stages/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/stages/**").hasRole("ADMIN")
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/backend/src/main/java/com/tokki/controller/StageController.java
+++ b/backend/src/main/java/com/tokki/controller/StageController.java
@@ -1,6 +1,7 @@
 package com.tokki.controller;
 
 import com.tokki.dto.request.CreateStageRequest;
+import com.tokki.dto.request.BatchUploadRequest;
 import com.tokki.dto.response.StageResponse;
 import com.tokki.dto.response.WordResponse;
 import com.tokki.service.StageService;
@@ -36,5 +37,23 @@ public class StageController {
     @PostMapping
     public ResponseEntity<StageResponse> createStage(@Valid @RequestBody CreateStageRequest request) {
         return ResponseEntity.ok(stageService.createStage(request));
+    }
+
+    @PutMapping("/{stageId}")
+    public ResponseEntity<StageResponse> updateStage(
+            @PathVariable Long stageId,
+            @Valid @RequestBody CreateStageRequest request) {
+        return ResponseEntity.ok(stageService.updateStage(stageId, request));
+    }
+
+    @DeleteMapping("/{stageId}")
+    public ResponseEntity<Void> deleteStage(@PathVariable Long stageId) {
+        stageService.deleteStage(stageId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/batch")
+    public ResponseEntity<List<StageResponse>> batchUpload(@Valid @RequestBody BatchUploadRequest request) {
+        return ResponseEntity.ok(stageService.batchUpload(request));
     }
 }

--- a/backend/src/main/java/com/tokki/domain/Stage.java
+++ b/backend/src/main/java/com/tokki/domain/Stage.java
@@ -33,4 +33,10 @@ public class Stage {
     protected void onCreate() {
         createdAt = LocalDateTime.now();
     }
+
+    public void update(String title, String description, Integer level) {
+        this.title = title;
+        this.description = description;
+        this.level = level;
+    }
 }

--- a/backend/src/main/java/com/tokki/domain/Word.java
+++ b/backend/src/main/java/com/tokki/domain/Word.java
@@ -43,4 +43,12 @@ public class Word {
     protected void onCreate() {
         createdAt = LocalDateTime.now();
     }
+
+    public void update(String word, String meaning, String example, String imageUrl, Integer orderIndex) {
+        this.word = word;
+        this.meaning = meaning;
+        this.example = example;
+        this.imageUrl = imageUrl;
+        this.orderIndex = orderIndex;
+    }
 }

--- a/backend/src/main/java/com/tokki/dto/request/BatchUploadRequest.java
+++ b/backend/src/main/java/com/tokki/dto/request/BatchUploadRequest.java
@@ -1,0 +1,16 @@
+package com.tokki.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class BatchUploadRequest {
+
+    @Valid
+    @NotEmpty
+    private List<CreateStageRequest> stages = new ArrayList<>();
+}

--- a/backend/src/main/java/com/tokki/dto/request/CreateStageRequest.java
+++ b/backend/src/main/java/com/tokki/dto/request/CreateStageRequest.java
@@ -1,22 +1,66 @@
 package com.tokki.dto.request;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import jakarta.validation.Valid;
 import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 public class CreateStageRequest {
 
-    @NotBlank
     @Size(max = 100)
     private String title;
 
     @Size(max = 500)
     private String description;
 
-    @NotNull
     @Min(1)
     private Integer level;
+
+    @NotBlank
+    @Size(max = 20)
+    private String difficulty;
+
+    @NotNull
+    @Min(1)
+    private Integer stageNumber;
+
+    @Valid
+    @NotEmpty
+    private List<WordItem> words = new ArrayList<>();
+
+    public String resolvedTitle() {
+        return title != null && !title.isBlank() ? title : difficulty;
+    }
+
+    public Integer resolvedLevel() {
+        return level != null ? level : stageNumber;
+    }
+
+    @Data
+    public static class WordItem {
+        @NotBlank
+        @Size(max = 100)
+        private String word;
+
+        @NotBlank
+        @Size(max = 200)
+        private String meaning;
+
+        @Size(max = 500)
+        private String example;
+
+        @Size(max = 500)
+        private String imageUrl;
+
+        @NotNull
+        @Min(1)
+        private Integer orderIndex;
+    }
 }

--- a/backend/src/main/java/com/tokki/dto/response/StageResponse.java
+++ b/backend/src/main/java/com/tokki/dto/response/StageResponse.java
@@ -35,6 +35,6 @@ public class StageResponse {
         if ("easy".equals(title) || "medium".equals(title) || "hard".equals(title)) {
             return title;
         }
-        return "easy";
+        return null;
     }
 }

--- a/backend/src/main/java/com/tokki/dto/response/StageResponse.java
+++ b/backend/src/main/java/com/tokki/dto/response/StageResponse.java
@@ -10,18 +10,31 @@ import java.time.LocalDateTime;
 @Builder
 public class StageResponse {
     private Long id;
+    private Long stageId;
     private String title;
     private String description;
     private Integer level;
+    private String difficulty;
+    private Integer stageNumber;
     private LocalDateTime createdAt;
 
     public static StageResponse from(Stage stage) {
         return StageResponse.builder()
                 .id(stage.getId())
+                .stageId(stage.getId())
                 .title(stage.getTitle())
                 .description(stage.getDescription())
                 .level(stage.getLevel())
+                .difficulty(difficulty(stage.getTitle()))
+                .stageNumber(stage.getLevel())
                 .createdAt(stage.getCreatedAt())
                 .build();
+    }
+
+    private static String difficulty(String title) {
+        if ("easy".equals(title) || "medium".equals(title) || "hard".equals(title)) {
+            return title;
+        }
+        return "easy";
     }
 }

--- a/backend/src/main/java/com/tokki/repository/WordRepository.java
+++ b/backend/src/main/java/com/tokki/repository/WordRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface WordRepository extends JpaRepository<Word, Long> {
     List<Word> findByStageIdOrderByOrderIndexAscIdAsc(Long stageId);
+    void deleteByStageId(Long stageId);
 }

--- a/backend/src/main/java/com/tokki/service/StageService.java
+++ b/backend/src/main/java/com/tokki/service/StageService.java
@@ -1,6 +1,8 @@
 package com.tokki.service;
 
 import com.tokki.domain.Stage;
+import com.tokki.domain.Word;
+import com.tokki.dto.request.BatchUploadRequest;
 import com.tokki.dto.request.CreateStageRequest;
 import com.tokki.dto.response.StageResponse;
 import com.tokki.dto.response.WordResponse;
@@ -13,6 +15,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -48,10 +53,64 @@ public class StageService {
     @Transactional
     public StageResponse createStage(CreateStageRequest request) {
         Stage stage = stageRepository.save(Stage.builder()
-                .title(request.getTitle())
+                .title(request.resolvedTitle())
                 .description(request.getDescription())
-                .level(request.getLevel())
+                .level(request.resolvedLevel())
                 .build());
+        saveWords(stage, request.getWords());
         return StageResponse.from(stage);
+    }
+
+    @Transactional
+    public StageResponse updateStage(Long stageId, CreateStageRequest request) {
+        Stage stage = stageRepository.findById(stageId)
+                .orElseThrow(() -> new AppException(ErrorCode.STAGE_NOT_FOUND));
+        stage.update(request.resolvedTitle(), request.getDescription(), request.resolvedLevel());
+        saveWords(stage, request.getWords());
+        return StageResponse.from(stage);
+    }
+
+    @Transactional
+    public void deleteStage(Long stageId) {
+        if (!stageRepository.existsById(stageId)) {
+            throw new AppException(ErrorCode.STAGE_NOT_FOUND);
+        }
+        wordRepository.deleteByStageId(stageId);
+        stageRepository.deleteById(stageId);
+    }
+
+    @Transactional
+    public List<StageResponse> batchUpload(BatchUploadRequest request) {
+        return request.getStages().stream()
+                .map(this::createStage)
+                .toList();
+    }
+
+    private void saveWords(Stage stage, List<CreateStageRequest.WordItem> wordItems) {
+        Map<Integer, Word> existingByOrder = wordRepository.findByStageIdOrderByOrderIndexAscIdAsc(stage.getId()).stream()
+                .collect(Collectors.toMap(Word::getOrderIndex, Function.identity(), (first, second) -> first));
+        List<Integer> requestedOrders = wordItems.stream()
+                .map(CreateStageRequest.WordItem::getOrderIndex)
+                .toList();
+
+        for (CreateStageRequest.WordItem item : wordItems) {
+            Word existing = existingByOrder.get(item.getOrderIndex());
+            if (existing == null) {
+                wordRepository.save(Word.builder()
+                        .stage(stage)
+                        .word(item.getWord())
+                        .meaning(item.getMeaning())
+                        .example(item.getExample())
+                        .imageUrl(item.getImageUrl())
+                        .orderIndex(item.getOrderIndex())
+                        .build());
+            } else {
+                existing.update(item.getWord(), item.getMeaning(), item.getExample(), item.getImageUrl(), item.getOrderIndex());
+            }
+        }
+
+        existingByOrder.values().stream()
+                .filter(word -> !requestedOrders.contains(word.getOrderIndex()))
+                .forEach(wordRepository::delete);
     }
 }

--- a/backend/src/test/java/com/tokki/service/StageServiceTest.java
+++ b/backend/src/test/java/com/tokki/service/StageServiceTest.java
@@ -1,0 +1,97 @@
+package com.tokki.service;
+
+import com.tokki.domain.Stage;
+import com.tokki.domain.Word;
+import com.tokki.dto.request.CreateStageRequest;
+import com.tokki.repository.StageRepository;
+import com.tokki.repository.WordRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StageServiceTest {
+
+    private final StageRepository stageRepository = mock(StageRepository.class);
+    private final WordRepository wordRepository = mock(WordRepository.class);
+    private final StageService stageService = new StageService(stageRepository, wordRepository);
+
+    @Test
+    void createStageSavesWordsWithFrontendContract() {
+        CreateStageRequest request = request("easy", 1, "morning", "아침");
+        Stage savedStage = Stage.builder()
+                .id(1L)
+                .title("easy")
+                .level(1)
+                .build();
+        when(stageRepository.save(any(Stage.class))).thenReturn(savedStage);
+        when(wordRepository.findByStageIdOrderByOrderIndexAscIdAsc(1L)).thenReturn(List.of());
+
+        stageService.createStage(request);
+
+        verify(wordRepository).save(any(Word.class));
+    }
+
+    @Test
+    void updateStageUpdatesExistingWordAndAddsMissingWord() {
+        Stage stage = Stage.builder()
+                .id(1L)
+                .title("easy")
+                .level(1)
+                .build();
+        Word existingWord = Word.builder()
+                .id(10L)
+                .stage(stage)
+                .word("old")
+                .meaning("이전")
+                .orderIndex(1)
+                .build();
+        CreateStageRequest request = request("medium", 2, "new", "새로운");
+        request.getWords().add(word("second", "두번째", 2));
+
+        when(stageRepository.findById(1L)).thenReturn(Optional.of(stage));
+        when(wordRepository.findByStageIdOrderByOrderIndexAscIdAsc(1L)).thenReturn(List.of(existingWord));
+
+        stageService.updateStage(1L, request);
+
+        assertThat(stage.getTitle()).isEqualTo("medium");
+        assertThat(stage.getLevel()).isEqualTo(2);
+        assertThat(existingWord.getWord()).isEqualTo("new");
+        assertThat(existingWord.getMeaning()).isEqualTo("새로운");
+        verify(wordRepository, times(1)).save(any(Word.class));
+    }
+
+    @Test
+    void deleteStageDeletesWordsBeforeStage() {
+        when(stageRepository.existsById(1L)).thenReturn(true);
+
+        stageService.deleteStage(1L);
+
+        verify(wordRepository).deleteByStageId(1L);
+        verify(stageRepository).deleteById(1L);
+    }
+
+    private CreateStageRequest request(String difficulty, int stageNumber, String word, String meaning) {
+        CreateStageRequest request = new CreateStageRequest();
+        request.setDifficulty(difficulty);
+        request.setStageNumber(stageNumber);
+        request.setWords(new ArrayList<>(List.of(word(word, meaning, 1))));
+        return request;
+    }
+
+    private CreateStageRequest.WordItem word(String word, String meaning, int orderIndex) {
+        CreateStageRequest.WordItem item = new CreateStageRequest.WordItem();
+        item.setWord(word);
+        item.setMeaning(meaning);
+        item.setOrderIndex(orderIndex);
+        return item;
+    }
+}

--- a/frontend/src/services/StageService.ts
+++ b/frontend/src/services/StageService.ts
@@ -35,7 +35,14 @@ function normalizeStage(
 
 export class StageService {
   static async getStages(): Promise<Stage[]> {
-    return (await http.get('/stages')) as unknown as Stage[];
+    const stages = (await http.get('/stages')) as unknown as Array<Record<string, unknown>>;
+    return Promise.all(
+      stages.map(async (stageRaw) => {
+        const stageId = Number(stageRaw.stageId ?? stageRaw.id ?? 0);
+        const wordsRaw = stageId > 0 ? await http.get(`/stages/${stageId}/words`) : [];
+        return normalizeStage(stageRaw, stageId, wordsRaw);
+      }),
+    );
   }
 
   static async getStageById(stageId: number): Promise<Stage> {


### PR DESCRIPTION
## Summary
- Add admin-protected create, update, delete, and batch endpoints for stages and their words.
- Extend the stage request/response contract to accept the frontend difficulty, stageNumber, and words shape while preserving the existing stage table mapping.
- Persist word edits with stage updates so learning and quiz views reflect admin changes.
- Hydrate stage lists with words on the frontend so the Admin page can edit existing data reliably.
- Add StageService tests for create/update/delete behavior.

## Validation
- ./gradlew.bat test
- corepack npm run build

Closes #35
Refs #31