### PR TITLE
[codex] Load production env during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,19 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Restore production environment
+        env:
+          TOKKI_ENV: ${{ secrets.TOKKI_ENV }}
+        run: |
+          if [ -z "$TOKKI_ENV" ]; then
+            echo "Missing required GitHub secret: TOKKI_ENV"
+            exit 1
+          fi
+          printf '%s\n' "$TOKKI_ENV" > .env
+          test -s .env
+          grep -q '^VITE_FIREBASE_API_KEY=' .env
+          grep -q '^FIREBASE_PROJECT_ID=' .env
+
       - name: Build backend (Gradle)
         run: |
           cd backend
@@ -123,6 +136,16 @@ jobs:
           source: "frontend/dist/*"
           target: "/opt/tokki/frontend/dist/"
           strip_components: 2
+          overwrite: true
+
+      - name: Transfer production environment to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          source: ".env"
+          target: "/opt/tokki/"
           overwrite: true
 
       # ==========================================


### PR DESCRIPTION
## Summary
- restore the production .env from the TOKKI_ENV repository secret before the frontend/backend build steps
- upload the same .env to /opt/tokki/.env so the deployed Spring Boot app can read runtime config
- fail early when Firebase env keys are missing instead of deploying a frontend bundle that throws FIREBASE_NOT_CONFIGURED

## Why
FIREBASE_NOT_CONFIGURED is thrown by the frontend when VITE_FIREBASE_API_KEY is absent at Vite build time. The current deploy build runs in GitHub Actions, so the local .env file is not available unless the workflow recreates it from repository secrets.

## Required repository secret
- Add TOKKI_ENV containing the production .env content.
- It must include VITE_FIREBASE_* for the frontend build and FIREBASE_* for backend Firebase Admin SDK runtime.
- Keep FIREBASE_PRIVATE_KEY escaped as \\n on one line if using env-var based service account credentials.

## Verification
- gh secret list --repo 26-smu-softeng-06t/TOKKI
- git diff --check