### PR TITLE
Fix local admin stage database access

### DIFF
--- a/backend/src/main/java/com/tokki/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tokki/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.tokki.auth.handler.OAuth2FailureHandler;
 import com.tokki.auth.handler.OAuth2SuccessHandler;
 import com.tokki.auth.service.CustomOAuth2UserService;
 import com.tokki.repository.UserRepository;
+import com.tokki.security.DevAuthenticationFilter;
 import com.tokki.security.FirebaseTokenFilter;
 import com.tokki.security.JwtAuthenticationFilter;
 import com.tokki.security.JwtProvider;
@@ -40,7 +41,13 @@ public class SecurityConfig {
     }
 
     @Bean
+    public DevAuthenticationFilter devAuthenticationFilter() {
+        return new DevAuthenticationFilter();
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http,
+                                           DevAuthenticationFilter devAuthenticationFilter,
                                            JwtAuthenticationFilter jwtAuthenticationFilter,
                                            FirebaseTokenFilter firebaseTokenFilter,
                                            RestAuthenticationEntryPoint authenticationEntryPoint,
@@ -65,6 +72,7 @@ public class SecurityConfig {
                                 "/ws/**",
                                 "/actuator/health"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/stages/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/stages/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/stages/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/stages/**").hasRole("ADMIN")
@@ -78,6 +86,7 @@ public class SecurityConfig {
                         .successHandler(oauth2SuccessHandler)
                         .failureHandler(oauth2FailureHandler)
                 )
+                .addFilterBefore(devAuthenticationFilter, JwtAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(firebaseTokenFilter, JwtAuthenticationFilter.class)
                 .build();

--- a/backend/src/main/java/com/tokki/security/DevAuthenticationFilter.java
+++ b/backend/src/main/java/com/tokki/security/DevAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.tokki.security;
+
+import com.tokki.domain.UserRole;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.List;
+
+public class DevAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String DEV_USER_HEADER = "X-TOKKI-DEV-USER";
+    private static final String DEV_ROLE_HEADER = "X-TOKKI-DEV-ROLE";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (SecurityContextHolder.getContext().getAuthentication() != null || !isDevAuthRequest(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        UserRole role = resolveRole(request.getHeader(DEV_ROLE_HEADER));
+        AuthUser authUser = new AuthUser("dev-uid", "dev@localhost", role);
+        String authority = "ROLE_" + role.name().toUpperCase();
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                authUser, null, List.of(new SimpleGrantedAuthority(authority)));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isDevAuthRequest(HttpServletRequest request) {
+        return "true".equalsIgnoreCase(request.getHeader(DEV_USER_HEADER)) && isLoopbackRequest(request);
+    }
+
+    private boolean isLoopbackRequest(HttpServletRequest request) {
+        String remoteAddr = request.getRemoteAddr();
+        if (!StringUtils.hasText(remoteAddr)) {
+            return false;
+        }
+
+        try {
+            return InetAddress.getByName(remoteAddr).isLoopbackAddress();
+        } catch (Exception ignored) {
+            return "127.0.0.1".equals(remoteAddr)
+                    || "0:0:0:0:0:0:0:1".equals(remoteAddr)
+                    || "::1".equals(remoteAddr);
+        }
+    }
+
+    private UserRole resolveRole(String rawRole) {
+        if ("admin".equalsIgnoreCase(rawRole)) {
+            return UserRole.admin;
+        }
+        return UserRole.user;
+    }
+}

--- a/backend/src/test/java/com/tokki/security/DevAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/tokki/security/DevAuthenticationFilterTest.java
@@ -1,0 +1,47 @@
+package com.tokki.security;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DevAuthenticationFilterTest {
+
+    private final DevAuthenticationFilter filter = new DevAuthenticationFilter();
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void authenticatesDevAdminForLoopbackRequest() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("127.0.0.1");
+        request.addHeader("X-TOKKI-DEV-USER", "true");
+        request.addHeader("X-TOKKI-DEV-ROLE", "admin");
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getAuthorities())
+                .extracting("authority")
+                .containsExactly("ROLE_ADMIN");
+    }
+
+    @Test
+    void ignoresDevHeaderForNonLoopbackRequest() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("203.0.113.10");
+        request.addHeader("X-TOKKI-DEV-USER", "true");
+        request.addHeader("X-TOKKI-DEV-ROLE", "admin");
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+}

--- a/frontend/src/lib/axios.ts
+++ b/frontend/src/lib/axios.ts
@@ -4,6 +4,7 @@ import { auth, firebaseConfigured } from './firebase';
 const ACCESS_TOKEN_KEY = 'tokki.accessToken';
 const rawApiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/+$/, '');
 const shouldUseDevProxy = import.meta.env.DEV;
+const shouldUseDevAuth = import.meta.env.DEV && import.meta.env.VITE_AUTH_DEV_USER === 'true';
 const normalizedApiBaseUrl = rawApiBaseUrl
   ? rawApiBaseUrl.endsWith('/api') ? rawApiBaseUrl : `${rawApiBaseUrl}/api`
   : '/api';
@@ -34,6 +35,12 @@ const apiClient = axios.create({
 });
 
 apiClient.interceptors.request.use(async (config) => {
+  if (shouldUseDevAuth) {
+    config.headers['X-TOKKI-DEV-USER'] = 'true';
+    config.headers['X-TOKKI-DEV-ROLE'] = 'admin';
+    return config;
+  }
+
   const token = firebaseConfigured && auth.currentUser
     ? await auth.currentUser.getIdToken()
     : getStoredAccessToken();


### PR DESCRIPTION
## Summary
- Fixes #66
- Adds explicit local dev admin auth headers from the frontend when VITE_AUTH_DEV_USER=true
- Authenticates those dev headers only for loopback backend requests
- Allows public stage reads while preserving ADMIN-only stage writes

## Verification
- ./gradlew.bat :backend:test --tests com.tokki.security.DevAuthenticationFilterTest --tests com.tokki.security.JwtProviderTest
- frontend Vite build