### PR TITLE
Implement US-11 Excel stage upload preview

### DIFF
--- a/backend/src/main/java/com/tokki/controller/StageController.java
+++ b/backend/src/main/java/com/tokki/controller/StageController.java
@@ -2,13 +2,17 @@ package com.tokki.controller;
 
 import com.tokki.dto.request.BatchStageRequest;
 import com.tokki.dto.request.CreateStageRequest;
+import com.tokki.dto.response.ExcelUploadPreviewResponse;
 import com.tokki.dto.response.StageResponse;
 import com.tokki.dto.response.WordResponse;
+import com.tokki.service.ExcelStageUploadService;
 import com.tokki.service.StageService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -18,6 +22,7 @@ import java.util.List;
 public class StageController {
 
     private final StageService stageService;
+    private final ExcelStageUploadService excelStageUploadService;
 
     @GetMapping
     public ResponseEntity<List<StageResponse>> getStages(
@@ -57,5 +62,10 @@ public class StageController {
     @PostMapping("/batch")
     public ResponseEntity<List<StageResponse>> batchUploadStages(@Valid @RequestBody BatchStageRequest request) {
         return ResponseEntity.ok(stageService.batchUpsertStages(request));
+    }
+
+    @PostMapping(value = "/excel/preview", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ExcelUploadPreviewResponse> previewExcelUpload(@RequestPart("file") MultipartFile file) {
+        return ResponseEntity.ok(excelStageUploadService.preview(file));
     }
 }

--- a/backend/src/main/java/com/tokki/dto/response/ExcelUploadPreviewResponse.java
+++ b/backend/src/main/java/com/tokki/dto/response/ExcelUploadPreviewResponse.java
@@ -1,0 +1,13 @@
+package com.tokki.dto.response;
+
+import com.tokki.dto.request.CreateStageRequest;
+
+import java.util.List;
+
+public record ExcelUploadPreviewResponse(
+        boolean valid,
+        int rowCount,
+        List<CreateStageRequest> stages,
+        List<ExcelUploadRowError> errors
+) {
+}

--- a/backend/src/main/java/com/tokki/dto/response/ExcelUploadRowError.java
+++ b/backend/src/main/java/com/tokki/dto/response/ExcelUploadRowError.java
@@ -1,0 +1,8 @@
+package com.tokki.dto.response;
+
+public record ExcelUploadRowError(
+        int rowNumber,
+        String field,
+        String message
+) {
+}

--- a/backend/src/main/java/com/tokki/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/tokki/exception/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.tokki.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -15,6 +17,9 @@ import java.util.Map;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @Value("${spring.servlet.multipart.max-file-size:5MB}")
+    private String maxUploadSize;
 
     @ExceptionHandler(AppException.class)
     public ResponseEntity<Map<String, Object>> handleAppException(AppException e) {
@@ -41,6 +46,13 @@ public class GlobalExceptionHandler {
         log.warn("Invalid input: {}", e.getMessage());
         return ResponseEntity.badRequest()
                 .body(Map.of("error", ErrorCode.INVALID_INPUT.name(), "message", ErrorCode.INVALID_INPUT.getMessage()));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<Map<String, Object>> handleMaxUploadSizeExceeded(MaxUploadSizeExceededException e) {
+        log.warn("Max upload size exceeded: {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(Map.of("error", ErrorCode.INVALID_INPUT.name(), "message", maxUploadSize + " 이하 파일만 업로드할 수 있습니다."));
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/tokki/service/ExcelStageUploadService.java
+++ b/backend/src/main/java/com/tokki/service/ExcelStageUploadService.java
@@ -1,0 +1,220 @@
+package com.tokki.service;
+
+import com.tokki.domain.DifficultyLevel;
+import com.tokki.dto.request.CreateStageRequest;
+import com.tokki.dto.request.StageWordRequest;
+import com.tokki.dto.response.ExcelUploadPreviewResponse;
+import com.tokki.dto.response.ExcelUploadRowError;
+import com.tokki.exception.AppException;
+import com.tokki.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+@Service
+@RequiredArgsConstructor
+public class ExcelStageUploadService {
+
+    private static final long MAX_FILE_SIZE = 5L * 1024L * 1024L;
+    private static final Set<String> REQUIRED_HEADERS = Set.of(
+            "difficulty", "stagenumber", "orderindex", "word", "meaning"
+    );
+
+    public ExcelUploadPreviewResponse preview(MultipartFile file) {
+        validateFile(file);
+
+        try (Workbook workbook = new XSSFWorkbook(file.getInputStream())) {
+            Sheet sheet = workbook.getNumberOfSheets() > 0 ? workbook.getSheetAt(0) : null;
+            if (sheet == null) {
+                throw new AppException(ErrorCode.INVALID_INPUT);
+            }
+
+            DataFormatter formatter = new DataFormatter();
+            Map<String, Integer> headers = readHeaders(sheet.getRow(0), formatter);
+            List<ExcelUploadRowError> errors = new ArrayList<>(validateHeaders(headers));
+            Map<String, StageDraft> drafts = new LinkedHashMap<>();
+            int rowCount = 0;
+
+            for (int i = 1; i <= sheet.getLastRowNum(); i++) {
+                Row row = sheet.getRow(i);
+                if (row == null || isBlankRow(row, formatter)) {
+                    continue;
+                }
+                rowCount++;
+                readRow(row, i + 1, headers, formatter, drafts, errors);
+            }
+
+            List<CreateStageRequest> stages = drafts.values().stream()
+                    .map(StageDraft::toRequest)
+                    .sorted(Comparator.comparing(CreateStageRequest::getDifficulty)
+                            .thenComparing(CreateStageRequest::getStageNumber))
+                    .toList();
+            if (rowCount == 0) {
+                errors.add(new ExcelUploadRowError(1, "file", "업로드할 데이터 행이 없습니다."));
+            }
+
+            return new ExcelUploadPreviewResponse(errors.isEmpty(), rowCount, stages, errors);
+        } catch (IOException e) {
+            throw new AppException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new AppException(ErrorCode.INVALID_INPUT);
+        }
+        String filename = file.getOriginalFilename() == null ? "" : file.getOriginalFilename().toLowerCase(Locale.ROOT);
+        if (!filename.endsWith(".xlsx") || file.getSize() > MAX_FILE_SIZE) {
+            throw new AppException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private Map<String, Integer> readHeaders(Row headerRow, DataFormatter formatter) {
+        Map<String, Integer> headers = new HashMap<>();
+        if (headerRow == null) {
+            return headers;
+        }
+        for (int i = 0; i < headerRow.getLastCellNum(); i++) {
+            String header = normalizeHeader(formatter.formatCellValue(headerRow.getCell(i)));
+            if (!header.isBlank()) {
+                headers.put(header, i);
+            }
+        }
+        return headers;
+    }
+
+    private List<ExcelUploadRowError> validateHeaders(Map<String, Integer> headers) {
+        List<ExcelUploadRowError> errors = new ArrayList<>();
+        for (String required : REQUIRED_HEADERS) {
+            if (!headers.containsKey(required)) {
+                errors.add(new ExcelUploadRowError(1, required, "필수 컬럼이 없습니다."));
+            }
+        }
+        return errors;
+    }
+
+    private void readRow(Row row, int rowNumber, Map<String, Integer> headers, DataFormatter formatter,
+                         Map<String, StageDraft> drafts, List<ExcelUploadRowError> errors) {
+        String difficultyValue = value(row, headers, formatter, "difficulty");
+        String stageNumberValue = value(row, headers, formatter, "stagenumber");
+        String orderIndexValue = value(row, headers, formatter, "orderindex");
+        String word = value(row, headers, formatter, "word");
+        String meaning = value(row, headers, formatter, "meaning");
+        String example = value(row, headers, formatter, "example");
+        String imageUrl = value(row, headers, formatter, "imageurl");
+
+        DifficultyLevel difficulty = parseDifficulty(difficultyValue, rowNumber, errors);
+        Integer stageNumber = parseBoundedNumber(stageNumberValue, rowNumber, "stageNumber", errors);
+        Integer orderIndex = parseBoundedNumber(orderIndexValue, rowNumber, "orderIndex", errors);
+        requireText(word, rowNumber, "word", errors);
+        requireText(meaning, rowNumber, "meaning", errors);
+
+        if (difficulty == null || stageNumber == null || orderIndex == null || word.isBlank() || meaning.isBlank()) {
+            return;
+        }
+
+        String key = difficulty.name() + ":" + stageNumber;
+        StageDraft draft = drafts.computeIfAbsent(key, ignored -> new StageDraft(difficulty, stageNumber));
+        if (!draft.orderIndexes.add(orderIndex)) {
+            errors.add(new ExcelUploadRowError(rowNumber, "orderIndex", "같은 스테이지 안에서 orderIndex가 중복되었습니다."));
+            return;
+        }
+        draft.words.add(toWordRequest(word, meaning, example, imageUrl, orderIndex));
+        if (draft.words.size() > 10) {
+            errors.add(new ExcelUploadRowError(rowNumber, "stage", "하나의 스테이지에는 최대 10개 단어만 업로드할 수 있습니다."));
+        }
+    }
+
+    private StageWordRequest toWordRequest(String word, String meaning, String example, String imageUrl, Integer orderIndex) {
+        StageWordRequest request = new StageWordRequest();
+        request.setWord(word);
+        request.setMeaning(meaning);
+        request.setExample(example.isBlank() ? null : example);
+        request.setImageUrl(imageUrl.isBlank() ? null : imageUrl);
+        request.setOrderIndex(orderIndex);
+        return request;
+    }
+
+    private DifficultyLevel parseDifficulty(String value, int rowNumber, List<ExcelUploadRowError> errors) {
+        try {
+            return DifficultyLevel.from(value);
+        } catch (IllegalArgumentException e) {
+            errors.add(new ExcelUploadRowError(rowNumber, "difficulty", "easy, medium, hard 중 하나여야 합니다."));
+            return null;
+        }
+    }
+
+    private Integer parseBoundedNumber(String value, int rowNumber, String field, List<ExcelUploadRowError> errors) {
+        try {
+            int number = Integer.parseInt(value);
+            if (number < 1 || number > 10) {
+                errors.add(new ExcelUploadRowError(rowNumber, field, "1부터 10 사이의 숫자여야 합니다."));
+                return null;
+            }
+            return number;
+        } catch (NumberFormatException e) {
+            errors.add(new ExcelUploadRowError(rowNumber, field, "숫자여야 합니다."));
+            return null;
+        }
+    }
+
+    private void requireText(String value, int rowNumber, String field, List<ExcelUploadRowError> errors) {
+        if (value.isBlank()) {
+            errors.add(new ExcelUploadRowError(rowNumber, field, "필수값입니다."));
+        }
+    }
+
+    private String value(Row row, Map<String, Integer> headers, DataFormatter formatter, String header) {
+        Integer index = headers.get(header);
+        if (index == null) {
+            return "";
+        }
+        return formatter.formatCellValue(row.getCell(index)).trim();
+    }
+
+    private boolean isBlankRow(Row row, DataFormatter formatter) {
+        for (int i = 0; i < row.getLastCellNum(); i++) {
+            if (!formatter.formatCellValue(row.getCell(i)).trim().isBlank()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String normalizeHeader(String value) {
+        return value.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
+    }
+
+    private record StageDraft(DifficultyLevel difficulty, Integer stageNumber, List<StageWordRequest> words,
+                              Set<Integer> orderIndexes) {
+        StageDraft(DifficultyLevel difficulty, Integer stageNumber) {
+            this(difficulty, stageNumber, new ArrayList<>(), new TreeSet<>());
+        }
+
+        CreateStageRequest toRequest() {
+            CreateStageRequest request = new CreateStageRequest();
+            request.setDifficulty(difficulty);
+            request.setStageNumber(stageNumber);
+            request.setWords(words.stream()
+                    .sorted(Comparator.comparing(StageWordRequest::getOrderIndex))
+                    .toList());
+            return request;
+        }
+    }
+}

--- a/backend/src/main/java/com/tokki/service/ExcelStageUploadService.java
+++ b/backend/src/main/java/com/tokki/service/ExcelStageUploadService.java
@@ -149,8 +149,17 @@ public class ExcelStageUploadService {
     }
 
     private DifficultyLevel parseDifficulty(String value, int rowNumber, List<ExcelUploadRowError> errors) {
+        if (value == null || value.isBlank()) {
+            errors.add(new ExcelUploadRowError(rowNumber, "difficulty", "필수값입니다."));
+            return null;
+        }
+
         try {
-            return DifficultyLevel.from(value);
+            DifficultyLevel difficulty = DifficultyLevel.from(value);
+            if (difficulty == null) {
+                errors.add(new ExcelUploadRowError(rowNumber, "difficulty", "필수값입니다."));
+            }
+            return difficulty;
         } catch (IllegalArgumentException e) {
             errors.add(new ExcelUploadRowError(rowNumber, "difficulty", "easy, medium, hard 중 하나여야 합니다."));
             return null;

--- a/backend/src/main/java/com/tokki/service/ExcelStageUploadService.java
+++ b/backend/src/main/java/com/tokki/service/ExcelStageUploadService.java
@@ -136,9 +136,6 @@ public class ExcelStageUploadService {
             return;
         }
         draft.words.add(toWordRequest(word, meaning, example, imageUrl, orderIndex));
-        if (draft.words.size() > 10) {
-            errors.add(new ExcelUploadRowError(rowNumber, "stage", "하나의 스테이지에는 최대 10개 단어만 업로드할 수 있습니다."));
-        }
     }
 
     private StageWordRequest toWordRequest(String word, String meaning, String example, String imageUrl, Integer orderIndex) {

--- a/backend/src/main/java/com/tokki/service/ExcelStageUploadService.java
+++ b/backend/src/main/java/com/tokki/service/ExcelStageUploadService.java
@@ -155,11 +155,7 @@ public class ExcelStageUploadService {
         }
 
         try {
-            DifficultyLevel difficulty = DifficultyLevel.from(value);
-            if (difficulty == null) {
-                errors.add(new ExcelUploadRowError(rowNumber, "difficulty", "필수값입니다."));
-            }
-            return difficulty;
+            return DifficultyLevel.from(value);
         } catch (IllegalArgumentException e) {
             errors.add(new ExcelUploadRowError(rowNumber, "difficulty", "easy, medium, hard 중 하나여야 합니다."));
             return null;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -36,6 +36,10 @@ spring:
           google:
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
             user-name-attribute: sub
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
 
 server:
   port: ${SERVER_PORT:8080}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { StageService } from '../services/StageService';
-import type { DifficultyLevel, Stage, StageInput } from '../types';
+import type { DifficultyLevel, ExcelUploadPreview, Stage, StageInput } from '../types';
 
 const SEED_DATA: StageInput[] = (['easy', 'medium', 'hard'] as DifficultyLevel[]).flatMap(
   (difficulty) =>
@@ -49,6 +49,9 @@ export default function AdminPage() {
   const [loading, setLoading] = useState(true);
   const [seeding, setSeeding] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [previewingUpload, setPreviewingUpload] = useState(false);
+  const [uploadingExcel, setUploadingExcel] = useState(false);
+  const [excelPreview, setExcelPreview] = useState<ExcelUploadPreview | null>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [formData, setFormData] = useState<FormData>(INITIAL_FORM);
 
@@ -127,6 +130,49 @@ export default function AdminPage() {
       fetchStages();
     } catch {
       toast.error('삭제에 실패했습니다.');
+    }
+  }
+
+  async function handleExcelFile(file: File | null) {
+    setExcelPreview(null);
+    if (!file) return;
+    if (!file.name.toLowerCase().endsWith('.xlsx')) {
+      toast.error('.xlsx 파일만 업로드할 수 있습니다.');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error('5MB 이하 파일만 업로드할 수 있습니다.');
+      return;
+    }
+
+    setPreviewingUpload(true);
+    try {
+      const preview = await StageService.previewExcelUpload(file);
+      setExcelPreview(preview);
+      if (preview.valid) {
+        toast.success(`${preview.rowCount}개 행을 확인했습니다.`);
+      } else {
+        toast.error('엑셀 검증 오류를 확인해주세요.');
+      }
+    } catch {
+      toast.error('엑셀 파일을 미리보기 할 수 없습니다.');
+    } finally {
+      setPreviewingUpload(false);
+    }
+  }
+
+  async function handleConfirmExcelUpload() {
+    if (!excelPreview?.valid || excelPreview.stages.length === 0) return;
+    setUploadingExcel(true);
+    try {
+      await StageService.batchUploadStages(excelPreview.stages);
+      toast.success('엑셀 데이터가 DB에 반영되었습니다.');
+      setExcelPreview(null);
+      fetchStages();
+    } catch {
+      toast.error('엑셀 데이터 반영에 실패했습니다.');
+    } finally {
+      setUploadingExcel(false);
     }
   }
 
@@ -249,24 +295,57 @@ export default function AdminPage() {
               {saving ? 'Saving...' : '💾 Save Stage'}
             </button>
 
-            {/* Bulk Upload Stub */}
+            {/* Bulk Upload */}
             <div>
               <h3 className="text-sm font-bold text-slate-700 mb-2">📂 Bulk Upload (Excel)</h3>
-              <div
-                className="border-2 border-dashed border-slate-300 rounded-xl p-8 text-center cursor-pointer"
-                onClick={() => toast.info('Phase 2에서 제공됩니다')}
-              >
-                <p className="text-sm text-slate-400">
-                  Drag &amp; drop .xlsx here or Browse File
-                </p>
-                <input type="file" accept=".xlsx" hidden />
-              </div>
+              <label className="block border-2 border-dashed border-slate-300 rounded-xl p-6 text-center cursor-pointer hover:border-indigo-300 hover:bg-indigo-50/40 transition-colors">
+                <span className="block text-sm text-slate-500">
+                  {previewingUpload ? 'Checking file...' : 'Choose .xlsx file for preview'}
+                </span>
+                <span className="block text-xs text-slate-400 mt-1">difficulty, stageNumber, orderIndex, word, meaning</span>
+                <input
+                  type="file"
+                  accept=".xlsx"
+                  disabled={previewingUpload}
+                  className="hidden"
+                  onChange={(e) => handleExcelFile(e.target.files?.[0] ?? null)}
+                />
+              </label>
+
+              {excelPreview && (
+                <div className="mt-3 rounded-xl border border-slate-200 bg-slate-50 p-3">
+                  <div className="flex items-center justify-between text-xs font-semibold text-slate-600 mb-2">
+                    <span>{excelPreview.rowCount} rows</span>
+                    <span>{excelPreview.stages.length} stages</span>
+                  </div>
+                  {excelPreview.errors.length > 0 ? (
+                    <div className="max-h-32 overflow-y-auto space-y-1">
+                      {excelPreview.errors.map((error, index) => (
+                        <p key={`${error.rowNumber}-${error.field}-${index}`} className="text-xs text-red-600">
+                          Row {error.rowNumber} · {error.field}: {error.message}
+                        </p>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="max-h-32 overflow-y-auto space-y-1">
+                      {excelPreview.stages.slice(0, 5).map((stage) => (
+                        <p key={`${stage.difficulty}-${stage.stageNumber}`} className="text-xs text-slate-600">
+                          {stage.difficulty} Stage {stage.stageNumber}: {stage.words.length} words
+                        </p>
+                      ))}
+                      {excelPreview.stages.length > 5 && (
+                        <p className="text-xs text-slate-400">+ {excelPreview.stages.length - 5} more stages</p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
               <button
-                disabled
-                onClick={() => toast.info('Phase 2에서 제공됩니다')}
-                className="mt-2 w-full py-2 bg-slate-100 text-slate-400 rounded-lg text-sm font-medium cursor-not-allowed"
+                disabled={!excelPreview?.valid || uploadingExcel}
+                onClick={handleConfirmExcelUpload}
+                className="mt-2 w-full py-2 bg-slate-900 hover:bg-slate-800 disabled:bg-slate-100 disabled:text-slate-400 disabled:cursor-not-allowed text-white rounded-lg text-sm font-medium"
               >
-                Upload to DB
+                {uploadingExcel ? 'Uploading...' : 'Upload to DB'}
               </button>
             </div>
           </div>

--- a/frontend/src/services/StageService.ts
+++ b/frontend/src/services/StageService.ts
@@ -1,6 +1,6 @@
 import http from '../lib/axios';
 import { MOCK_STAGE } from '../api/mockData';
-import type { Stage, DifficultyLevel, StageInput } from '../types';
+import type { Stage, DifficultyLevel, StageInput, ExcelUploadPreview } from '../types';
 
 function normalizeDifficulty(value: unknown): DifficultyLevel {
   const raw = String(value ?? 'easy').toLowerCase();
@@ -93,5 +93,13 @@ export class StageService {
 
   static async batchUploadStages(stages: StageInput[]): Promise<void> {
     await http.post('/stages/batch', { stages });
+  }
+
+  static async previewExcelUpload(file: File): Promise<ExcelUploadPreview> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return (await http.post('/stages/excel/preview', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })) as unknown as ExcelUploadPreview;
   }
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -47,7 +47,21 @@ export interface WordInput {
   word: string;
   meaning: string;
   example: string | null;
+  imageUrl?: string | null;
   orderIndex: number;
+}
+
+export interface ExcelUploadRowError {
+  rowNumber: number;
+  field: string;
+  message: string;
+}
+
+export interface ExcelUploadPreview {
+  valid: boolean;
+  rowCount: number;
+  stages: StageInput[];
+  errors: ExcelUploadRowError[];
 }
 
 export interface IncorrectWord {


### PR DESCRIPTION
## Summary
- Closes #68
- Closes #69
- Closes #70
- Advances #20
- Adds .xlsx upload preview parsing and validation for stage data
- Validates file type, 5MB limit, required columns, row values, and duplicate order indexes
- Adds admin preview UI and commits valid preview data through the existing batch upload path

## Verification
- ./gradlew.bat :backend:compileJava
- frontend tsc -b
- frontend Vite build