### PR TITLE
Implement US-13 offline progress sync

### DIFF
--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -4,6 +4,11 @@ import { CheckCircle, XCircle, ArrowLeft, ArrowRight, RotateCcw, Home, BookOpen,
 import { useAuth } from '../hooks/useAuth';
 import { StageService } from '../services/StageService';
 import { ProgressService } from '../services/ProgressService';
+import {
+  OfflineProgressQueue,
+  subscribeProgressSyncStatus,
+  type ProgressSyncStatus,
+} from '../services/OfflineProgressQueue';
 import { QuizSessionService } from '../services/QuizSessionService';
 import LoadingSpinner from '../components/LoadingSpinner';
 import type { Stage, Word, QuizMode, IncorrectWord } from '../types';
@@ -52,6 +57,9 @@ export default function QuizPage() {
   const [answer, setAnswer] = useState('');
   const [submitted, setSubmitted] = useState(false);
   const [results, setResults] = useState<QuestionResult[]>([]);
+  const [syncStatus, setSyncStatus] = useState<ProgressSyncStatus>(
+    OfflineProgressQueue.hasPending() ? 'queued' : 'idle',
+  );
 
   const inputRef = useRef<HTMLInputElement>(null);
   const nextBtnRef = useRef<HTMLButtonElement>(null);
@@ -91,6 +99,12 @@ export default function QuizPage() {
   useEffect(() => {
     if (phase === 'result') window.scrollTo({ top: 0, behavior: 'instant' });
   }, [phase]);
+
+  useEffect(() => subscribeProgressSyncStatus(setSyncStatus), []);
+
+  useEffect(() => {
+    void ProgressService.syncQueuedProgress();
+  }, []);
 
   useEffect(() => {
     if (phase === 'quiz' && !submitted) {
@@ -201,7 +215,12 @@ export default function QuizPage() {
       }
     } catch (err) {
       console.error('Failed to sync progress:', err);
-      // Even if sync fails, the local state was updated above, so Retry will work.
+      try {
+        await ProgressService.markStageCompleted(sId);
+      } catch {
+        // ProgressService has already queued the completion when a retry is possible.
+      }
+      setSyncStatus(OfflineProgressQueue.hasPending() ? 'queued' : 'failed');
     }
 
     // [4] Show Resolve Dialog if there are words to resolve
@@ -581,6 +600,22 @@ export default function QuizPage() {
       ? 'text-amber-600'
       : 'text-red-500';
 
+  const syncLabel: Record<ProgressSyncStatus, string> = {
+    idle: '저장 대기',
+    queued: '오프라인 저장됨',
+    syncing: '동기화 중',
+    synced: '저장 완료',
+    failed: '동기화 실패',
+  };
+
+  const syncClass: Record<ProgressSyncStatus, string> = {
+    idle: 'bg-slate-100 text-slate-500',
+    queued: 'bg-amber-100 text-amber-700',
+    syncing: 'bg-indigo-100 text-indigo-700',
+    synced: 'bg-green-100 text-green-700',
+    failed: 'bg-red-100 text-red-600',
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-sm animate-in fade-in duration-300">
       <div className="bg-white w-full max-w-lg rounded-[3rem] shadow-2xl overflow-hidden animate-in zoom-in-95 duration-300 flex flex-col max-h-[90vh]">
@@ -592,6 +627,11 @@ export default function QuizPage() {
             </div>
           </div>
           <h2 className={`text-lg font-black mb-0.5 ${scoreLabelColor}`}>{scoreLabel}</h2>
+          <div className="mb-2 flex justify-center">
+            <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${syncClass[syncStatus]}`}>
+              {syncLabel[syncStatus]}
+            </span>
+          </div>
           <div className="flex justify-center items-baseline gap-1.5">
             <span className="text-3xl font-black text-slate-900">{score}</span>
             <span className="text-slate-300 text-lg font-black">/</span>

--- a/frontend/src/services/OfflineProgressQueue.ts
+++ b/frontend/src/services/OfflineProgressQueue.ts
@@ -1,0 +1,90 @@
+import type { UserProgress } from '../types';
+
+export type ProgressSyncStatus = 'idle' | 'queued' | 'syncing' | 'synced' | 'failed';
+
+export interface OfflineProgressPayload extends Partial<UserProgress> {
+  stageId: number;
+  completed?: boolean;
+}
+
+export interface OfflineProgressItem {
+  id: string;
+  createdAt: string;
+  attempts: number;
+  payload: OfflineProgressPayload;
+}
+
+const STORAGE_KEY = 'tokki.offlineProgressQueue.v1';
+const SYNC_EVENT = 'tokki:progress-sync';
+
+function canUseStorage() {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function readQueue(): OfflineProgressItem[] {
+  if (!canUseStorage()) return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as OfflineProgressItem[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeQueue(items: OfflineProgressItem[]) {
+  if (!canUseStorage()) return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+}
+
+export function emitProgressSyncStatus(status: ProgressSyncStatus) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(SYNC_EVENT, { detail: { status } }));
+}
+
+export function subscribeProgressSyncStatus(listener: (status: ProgressSyncStatus) => void) {
+  const handler = (event: Event) => {
+    const customEvent = event as CustomEvent<{ status?: ProgressSyncStatus }>;
+    listener(customEvent.detail?.status ?? 'idle');
+  };
+  window.addEventListener(SYNC_EVENT, handler);
+  return () => window.removeEventListener(SYNC_EVENT, handler);
+}
+
+export class OfflineProgressQueue {
+  static all(): OfflineProgressItem[] {
+    return readQueue();
+  }
+
+  static hasPending(): boolean {
+    return readQueue().length > 0;
+  }
+
+  static enqueue(payload: OfflineProgressPayload): OfflineProgressItem {
+    const queue = readQueue();
+    const id = `${payload.stageId}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const nextItem: OfflineProgressItem = {
+      id,
+      createdAt: new Date().toISOString(),
+      attempts: 0,
+      payload,
+    };
+    const withoutSameStage = queue.filter((item) => item.payload.stageId !== payload.stageId);
+    writeQueue([...withoutSameStage, nextItem]);
+    emitProgressSyncStatus('queued');
+    return nextItem;
+  }
+
+  static remove(id: string) {
+    writeQueue(readQueue().filter((item) => item.id !== id));
+  }
+
+  static replace(item: OfflineProgressItem) {
+    writeQueue(readQueue().map((existing) => (existing.id === item.id ? item : existing)));
+  }
+
+  static findByStage(stageId: number): OfflineProgressItem | null {
+    return readQueue().find((item) => item.payload.stageId === stageId) ?? null;
+  }
+}
+
+export const progressSyncEventName = SYNC_EVENT;

--- a/frontend/src/services/ProgressService.ts
+++ b/frontend/src/services/ProgressService.ts
@@ -1,5 +1,10 @@
 import http from '../lib/axios';
 import type { UserProgress, IncorrectWord } from '../types';
+import {
+  emitProgressSyncStatus,
+  OfflineProgressQueue,
+  type OfflineProgressPayload,
+} from './OfflineProgressQueue';
 
 export class ProgressService {
   static async getProgress(stageId: number): Promise<UserProgress | null> {
@@ -7,6 +12,8 @@ export class ProgressService {
       const progresses = (await http.get('/progress')) as unknown as UserProgress[];
       return progresses.find((progress) => progress.stageId === stageId) ?? null;
     } catch (err) {
+      const queued = OfflineProgressQueue.findByStage(stageId);
+      if (queued) return queued.payload as UserProgress;
       const msg = err instanceof Error ? err.message : '';
       if (msg.includes('404') || msg === 'NOT_FOUND') return null;
       throw err;
@@ -14,11 +21,11 @@ export class ProgressService {
   }
 
   static async saveProgress(progress: UserProgress): Promise<void> {
-    await http.post('/progress', progress);
+    await saveOrQueue(progress);
   }
 
   static async markStageCompleted(stageId: number): Promise<void> {
-    await http.post('/progress', { stageId, completed: true });
+    await saveOrQueue({ stageId, completed: true });
   }
 
   static async getIncorrectWords(): Promise<IncorrectWord[]> {
@@ -36,4 +43,52 @@ export class ProgressService {
   static async resolveIncorrectWord(wordId: number): Promise<void> {
     await http.delete(`/progress/incorrect/${wordId}`);
   }
+
+  static async syncQueuedProgress(): Promise<void> {
+    await syncQueuedProgress();
+  }
+}
+
+async function saveOrQueue(payload: OfflineProgressPayload): Promise<void> {
+  if (typeof navigator !== 'undefined' && !navigator.onLine) {
+    OfflineProgressQueue.enqueue(payload);
+    return;
+  }
+
+  try {
+    await http.post('/progress', payload);
+    emitProgressSyncStatus(OfflineProgressQueue.hasPending() ? 'queued' : 'synced');
+  } catch (err) {
+    OfflineProgressQueue.enqueue(payload);
+    emitProgressSyncStatus('failed');
+    throw err;
+  }
+}
+
+async function syncQueuedProgress(): Promise<void> {
+  if (typeof navigator !== 'undefined' && !navigator.onLine) return;
+  const queue = OfflineProgressQueue.all();
+  if (queue.length === 0) {
+    emitProgressSyncStatus('synced');
+    return;
+  }
+
+  emitProgressSyncStatus('syncing');
+  for (const item of queue) {
+    try {
+      await http.post('/progress', item.payload);
+      OfflineProgressQueue.remove(item.id);
+    } catch {
+      OfflineProgressQueue.replace({ ...item, attempts: item.attempts + 1 });
+      emitProgressSyncStatus('failed');
+      return;
+    }
+  }
+  emitProgressSyncStatus('synced');
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('online', () => {
+    void syncQueuedProgress();
+  });
 }


### PR DESCRIPTION
## Summary
- Closes #71
- Closes #72
- Closes #73
- Advances #22
- Adds local progress queue storage for failed/offline progress writes
- Replays queued progress when the browser reconnects
- Shows sync status on quiz results so users can see queued/syncing/synced/failed states

## Verification
- frontend tsc -b
- frontend Vite build