### PR TITLE
Fix deploy health check for VPS 502

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,15 +177,17 @@ jobs:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.SSH_KEY }}
+          script_stop: true
           script: |
             echo "=== pm2 재시작 ==="
             cd /opt/tokki/backend
+            BACKEND_PORT=4000
 
             # 이미 pm2에 등록되어 있으면 restart, 없으면 start
             if pm2 describe tokki-backend > /dev/null 2>&1; then
-              pm2 restart tokki-backend --update-env
+              SERVER_PORT="$BACKEND_PORT" pm2 restart tokki-backend --update-env
             else
-              pm2 start java --name tokki-backend --time -- -jar app.jar
+              SERVER_PORT="$BACKEND_PORT" pm2 start java --name tokki-backend --time -- -jar app.jar
               pm2 save
             fi
 
@@ -193,14 +195,26 @@ jobs:
             pm2 status
 
             echo "=== 백엔드 헬스체크 (최대 30초 대기) ==="
+            backend_ready=0
             for i in $(seq 1 15); do
-              if curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:4000/api/auth/me | grep -qE "200|401|403"; then
+              http_code="$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${BACKEND_PORT}/api/auth/me" || true)"
+              if echo "$http_code" | grep -qE "200|401|403"; then
                 echo "✅ 백엔드 정상 응답 (시도 $i/15)"
+                backend_ready=1
                 break
               fi
-              echo "⏳ 백엔드 시작 대기 중... ($i/15)"
+              echo "⏳ 백엔드 시작 대기 중... ($i/15, status=${http_code})"
               sleep 2
             done
+
+            if [ "$backend_ready" -ne 1 ]; then
+              echo "❌ 백엔드가 ${BACKEND_PORT} 포트에서 정상 응답하지 않습니다."
+              echo "=== listening ports ==="
+              ss -ltnp || true
+              echo "=== pm2 logs: tokki-backend ==="
+              pm2 logs tokki-backend --lines 120 --nostream || true
+              exit 1
+            fi
 
       - name: Reload Nginx
         uses: appleboy/ssh-action@v1.0.3
@@ -227,6 +241,7 @@ jobs:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.SSH_KEY }}
+          script_stop: true
           script: |
             echo "=============================="
             echo "  🚀 배포 최종 검증 결과"
@@ -247,6 +262,14 @@ jobs:
             echo ""
             echo "[4] 백엔드 JAR 확인"
             ls -lh /opt/tokki/backend/app.jar
+
+            echo ""
+            echo "[5] 백엔드 직접 헬스체크"
+            curl -fsS -o /dev/null http://127.0.0.1:4000/api/auth/me
+
+            echo ""
+            echo "[6] Nginx 경유 API 헬스체크"
+            curl -fsS -o /dev/null http://127.0.0.1/api/auth/me
 
             echo ""
             echo "=============================="


### PR DESCRIPTION
## Summary
- Forces the PM2-managed Spring backend to run with SERVER_PORT=4000, matching the deploy health check and expected Nginx upstream.
- Makes the backend health loop fail the workflow if the backend never responds.
- Prints listening ports and PM2 logs on backend startup failure.
- Adds final direct-backend and Nginx-through API curl checks so a green deploy cannot still hide a 502.

## Diagnosis
The latest successful deploy run waited through all 15 backend health-check attempts against http://127.0.0.1:4000/api/auth/me, but the script did not exit nonzero. PM2 and Nginx were active, so Actions reported success while the backend upstream was not actually healthy.

## Verification
- Inspected latest deploy run 26068712056 logs
- Reviewed deploy.yml diff