### PR TITLE
Fix Firebase env fallback on VPS deploy

### DIFF
--- a/backend/src/main/java/com/tokki/config/FirebaseConfig.java
+++ b/backend/src/main/java/com/tokki/config/FirebaseConfig.java
@@ -41,14 +41,17 @@ public class FirebaseConfig {
 
         if (StringUtils.hasText(serviceAccountPath)) {
             Path credentialsPath = resolveServiceAccountPath(serviceAccountPath);
-            try (InputStream serviceAccount = Files.newInputStream(credentialsPath)) {
-                FirebaseOptions options = FirebaseOptions.builder()
-                        .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                        .build();
-                FirebaseApp.initializeApp(options);
-                log.info("Firebase initialized from service-account file: {}", credentialsPath.getFileName());
+            if (credentialsPath != null) {
+                try (InputStream serviceAccount = Files.newInputStream(credentialsPath)) {
+                    FirebaseOptions options = FirebaseOptions.builder()
+                            .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                            .build();
+                    FirebaseApp.initializeApp(options);
+                    log.info("Firebase initialized from service-account file: {}", credentialsPath.getFileName());
+                }
+                return;
             }
-            return;
+            log.warn("Firebase service-account file not found; falling back to env credentials");
         }
 
         if (!StringUtils.hasText(projectId) || !StringUtils.hasText(clientEmail) || !StringUtils.hasText(privateKey)) {
@@ -65,7 +68,7 @@ public class FirebaseConfig {
         log.info("Firebase initialized for project: {}", projectId);
     }
 
-    private Path resolveServiceAccountPath(String configuredPath) throws IOException {
+    private Path resolveServiceAccountPath(String configuredPath) {
         Path path = Path.of(configuredPath);
         if (Files.exists(path)) {
             return path.toAbsolutePath().normalize();
@@ -76,7 +79,7 @@ public class FirebaseConfig {
             return parentRelativePath.toAbsolutePath().normalize();
         }
 
-        throw new IOException("Firebase service account file not found: " + configuredPath);
+        return null;
     }
 
     private String buildServiceAccountJson(String projectId, String clientEmail, String privateKey) {

--- a/backend/src/test/java/com/tokki/config/FirebaseConfigTest.java
+++ b/backend/src/test/java/com/tokki/config/FirebaseConfigTest.java
@@ -1,0 +1,33 @@
+package com.tokki.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FirebaseConfigTest {
+
+    @Test
+    void missingServiceAccountPathDoesNotCrashPathResolution() throws Exception {
+        FirebaseConfig config = new FirebaseConfig();
+        Method method = FirebaseConfig.class.getDeclaredMethod("resolveServiceAccountPath", String.class);
+        method.setAccessible(true);
+
+        Object resolved = method.invoke(config, "../missing-firebase-service-account.json");
+
+        assertThat(resolved).isNull();
+    }
+
+    @Test
+    void envPrivateKeyNormalizesEscapedNewlines() throws Exception {
+        FirebaseConfig config = new FirebaseConfig();
+        Method method = FirebaseConfig.class.getDeclaredMethod("buildServiceAccountJson", String.class, String.class, String.class);
+        method.setAccessible(true);
+
+        String json = (String) method.invoke(config, "project-id", "firebase@example.com", "line1\\nline2");
+
+        assertThat(json).contains("line1\\nline2");
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes the backend startup failure exposed by the new deploy health check.
- If FIREBASE_SERVICE_ACCOUNT_PATH points to a missing file, the backend now falls back to FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, and FIREBASE_PRIVATE_KEY from the deployed env.
- Keeps file-based Firebase credentials working when the file actually exists.
- Adds focused FirebaseConfig tests.

## Diagnosis
The failed Action shows the backend never listened on port 4000 because Spring crashed during FirebaseConfig startup:

Caused by: java.io.IOException: Firebase service account file not found: ../smu-soft-eng-26-1st-firebase-adminsdk-fbsvc-c979ade230.json

The workflow already validates env-based Firebase keys, so a stale/missing service-account file path should not take precedence and kill the app.

## Verification
- ./gradlew.bat :backend:compileJava
- ./gradlew.bat :backend:test --tests com.tokki.config.FirebaseConfigTest