### PR TITLE
Organize deployment secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,12 +44,7 @@ VITE_FIREBASE_APP_ID=
 VITE_FIREBASE_MEASUREMENT_ID=
 
 # Backend Firebase Admin SDK
-# Prefer env-based credentials. Convert service-account JSON into these keys;
-# do not commit JSON key files.
+# Convert service-account JSON into these env keys; do not commit JSON key files.
 FIREBASE_PROJECT_ID=${VITE_FIREBASE_PROJECT_ID}
 FIREBASE_CLIENT_EMAIL=
 FIREBASE_PRIVATE_KEY=
-
-# Local-only fallback for a service-account JSON file.
-# Do not include this in TOKKI_ENV unless the file is deployed separately.
-FIREBASE_SERVICE_ACCOUNT_PATH=

--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,17 @@
-# TOKKI environment example
-# Copy this file to .env and fill in local secrets.
-# Backend imports TOKKI/.env from backend/application.yml.
-# Frontend imports TOKKI/.env through Vite envDir.
+# TOKKI environment example.
+# Copy this file to .env for local development.
+# For GitHub Actions, paste the production app-runtime keys into the TOKKI_ENV
+# repository secret. Keep VPS transport keys as separate GitHub secrets.
 
 APP_ENV=local
 APP_TIMEZONE=Asia/Seoul
 
-# MySQL / DigitalOcean
+# MySQL
 MYSQL_HOST=localhost
 MYSQL_PORT=3306
 MYSQL_DATABASE=tokki
-MYSQL_USERNAME=tokki_user
-MYSQL_PASSWORD=change-me
+MYSQL_USERNAME=
+MYSQL_PASSWORD=
 MYSQL_SSL_MODE=REQUIRED
 
 # Spring Boot datasource
@@ -23,7 +23,7 @@ SPRING_JPA_HIBERNATE_DDL_AUTO=validate
 # Generic database URL for tools that prefer one variable
 DATABASE_URL=mysql://${MYSQL_USERNAME}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?ssl-mode=${MYSQL_SSL_MODE}
 
-# Auth
+# Google OAuth / app auth
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 JWT_SECRET=
@@ -44,8 +44,12 @@ VITE_FIREBASE_APP_ID=
 VITE_FIREBASE_MEASUREMENT_ID=
 
 # Backend Firebase Admin SDK
-# Use a local service-account JSON file; never commit it.
-FIREBASE_SERVICE_ACCOUNT_PATH=
+# Prefer env-based credentials. Convert service-account JSON into these keys;
+# do not commit JSON key files.
 FIREBASE_PROJECT_ID=${VITE_FIREBASE_PROJECT_ID}
 FIREBASE_CLIENT_EMAIL=
 FIREBASE_PRIVATE_KEY=
+
+# Local-only fallback for a service-account JSON file.
+# Do not include this in TOKKI_ENV unless the file is deployed separately.
+FIREBASE_SERVICE_ACCOUNT_PATH=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,14 @@ jobs:
 
           missing=0
           required_keys=(
+            MYSQL_HOST
+            MYSQL_PORT
+            MYSQL_DATABASE
+            MYSQL_USERNAME
+            MYSQL_PASSWORD
+            SPRING_DATASOURCE_URL
+            JWT_SECRET
+            ADMIN_SECRET_KEY
             VITE_FIREBASE_API_KEY
             VITE_FIREBASE_AUTH_DOMAIN
             VITE_FIREBASE_PROJECT_ID
@@ -65,8 +73,33 @@ jobs:
             fi
           done
 
+          forbidden_keys=(
+            HOST
+            USERNAME
+            SSH_KEY
+            VPS_PASSWORD
+            VPS_PRIVATE_IP
+            VPS_PUB_IP
+            VPS_USER
+            DESIRED_PATH_URL
+            NAMECHEAP_URL
+            FIREBASE_SERVICE_ACCOUNT
+          )
+
+          for key in "${forbidden_keys[@]}"; do
+            if grep -q "^${key}=" .env; then
+              echo "Remove deployment-only key from TOKKI_ENV: ${key}"
+              missing=1
+            fi
+          done
+
+          if grep -q "^FIREBASE_SERVICE_ACCOUNT_PATH=." .env; then
+            echo "Do not use FIREBASE_SERVICE_ACCOUNT_PATH in TOKKI_ENV; use FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, and FIREBASE_PRIVATE_KEY."
+            missing=1
+          fi
+
           if [ "$missing" -ne 0 ]; then
-            echo "TOKKI_ENV must be the production .env content, not a single Firebase API key."
+            echo "TOKKI_ENV must contain only production app-runtime environment keys."
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,10 @@ frontend/dist/
 
 # misc
 *.pem
+*.pub
+*.key
+id_rsa*
+id_ed25519*
 
 # debug
 npm-debug.log*
@@ -243,6 +247,7 @@ yarn-error.log*
 
 # Firebase service account key files
 *-firebase-*.json
+*-firebase-adminsdk-*.json
 serviceAccountKey.json
 
 # vercel
@@ -694,6 +699,13 @@ FodyWeavers.xsd
 # Firebase service account credentials
 *firebase-adminsdk*.json
 serviceAccount*.json
+
+# Local CI/CD and deployment secrets
+.env.cicd
+.env.production
+.env.staging
+firebase-service-account*.json
+google-service-account*.json
 
 # Local working notes
 notes/

--- a/backend/src/main/java/com/tokki/config/FirebaseConfig.java
+++ b/backend/src/main/java/com/tokki/config/FirebaseConfig.java
@@ -13,8 +13,6 @@ import org.springframework.util.StringUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
 
 @Slf4j
@@ -23,9 +21,6 @@ public class FirebaseConfig {
 
     @Value("${firebase.project-id}")
     private String projectId;
-
-    @Value("${firebase.service-account-path:}")
-    private String serviceAccountPath;
 
     @Value("${firebase.client-email}")
     private String clientEmail;
@@ -37,21 +32,6 @@ public class FirebaseConfig {
     public void initializeFirebase() throws IOException {
         if (!FirebaseApp.getApps().isEmpty()) {
             return;
-        }
-
-        if (StringUtils.hasText(serviceAccountPath)) {
-            Path credentialsPath = resolveServiceAccountPath(serviceAccountPath);
-            if (credentialsPath != null) {
-                try (InputStream serviceAccount = Files.newInputStream(credentialsPath)) {
-                    FirebaseOptions options = FirebaseOptions.builder()
-                            .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                            .build();
-                    FirebaseApp.initializeApp(options);
-                    log.info("Firebase initialized from service-account file: {}", credentialsPath.getFileName());
-                }
-                return;
-            }
-            log.warn("Firebase service-account file not found; falling back to env credentials");
         }
 
         if (!StringUtils.hasText(projectId) || !StringUtils.hasText(clientEmail) || !StringUtils.hasText(privateKey)) {
@@ -66,20 +46,6 @@ public class FirebaseConfig {
                 .build();
         FirebaseApp.initializeApp(options);
         log.info("Firebase initialized for project: {}", projectId);
-    }
-
-    private Path resolveServiceAccountPath(String configuredPath) {
-        Path path = Path.of(configuredPath);
-        if (Files.exists(path)) {
-            return path.toAbsolutePath().normalize();
-        }
-
-        Path parentRelativePath = Path.of("..").resolve(configuredPath).normalize();
-        if (Files.exists(parentRelativePath)) {
-            return parentRelativePath.toAbsolutePath().normalize();
-        }
-
-        return null;
     }
 
     private String buildServiceAccountJson(String projectId, String clientEmail, String privateKey) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -79,7 +79,6 @@ tokki:
       measurement-id: ${VITE_FIREBASE_MEASUREMENT_ID:}
 
 firebase:
-  service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH:}
   project-id: ${FIREBASE_PROJECT_ID:${VITE_FIREBASE_PROJECT_ID:}}
   client-email: ${FIREBASE_CLIENT_EMAIL:}
   private-key: ${FIREBASE_PRIVATE_KEY:}

--- a/backend/src/test/java/com/tokki/config/FirebaseConfigTest.java
+++ b/backend/src/test/java/com/tokki/config/FirebaseConfigTest.java
@@ -1,7 +1,6 @@
 package com.tokki.config;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Method;
 
@@ -10,20 +9,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FirebaseConfigTest {
 
     @Test
-    void missingServiceAccountPathDoesNotCrashPathResolution() throws Exception {
-        FirebaseConfig config = new FirebaseConfig();
-        Method method = FirebaseConfig.class.getDeclaredMethod("resolveServiceAccountPath", String.class);
-        method.setAccessible(true);
-
-        Object resolved = method.invoke(config, "../missing-firebase-service-account.json");
-
-        assertThat(resolved).isNull();
-    }
-
-    @Test
     void envPrivateKeyNormalizesEscapedNewlines() throws Exception {
         FirebaseConfig config = new FirebaseConfig();
-        Method method = FirebaseConfig.class.getDeclaredMethod("buildServiceAccountJson", String.class, String.class, String.class);
+        Method method = FirebaseConfig.class.getDeclaredMethod(
+                "buildServiceAccountJson",
+                String.class,
+                String.class,
+                String.class
+        );
         method.setAccessible(true);
 
         String json = (String) method.invoke(config, "project-id", "firebase@example.com", "line1\\nline2");

--- a/docs/secret_guides.md
+++ b/docs/secret_guides.md
@@ -1,48 +1,38 @@
-# TOKKI Secret Guide
+# TOKKI 시크릿 관리 가이드
 
-Secrets are distributed out of band through Discord. Do not commit `.env`, `.env.cicd`, Firebase service-account JSON files, `.pem`, `.pub`, or private key material.
+시크릿 값은 Discord로 별도 배포한다. `.env`, `.env.cicd`, Firebase 서비스 계정 JSON, `.pem`, `.pub`, 개인키 파일은 커밋하지 않는다.
 
 ## GitHub Secrets
 
-Use these repository secrets for deployment transport only:
+배포 연결 정보는 GitHub repository secret으로 분리해서 관리한다.
 
-- `HOST`: VPS public host or IP.
-- `USERNAME`: SSH user for the VPS.
-- `SSH_KEY`: private SSH key for deployment.
-- `TOKKI_ENV`: full production app runtime `.env` content.
+- `HOST`: VPS 공개 호스트 또는 IP.
+- `USERNAME`: VPS SSH 사용자.
+- `SSH_KEY`: 배포용 SSH private key.
+- `TOKKI_ENV`: 운영 앱 런타임 `.env` 전체 내용.
 
-Do not place `HOST`, `USERNAME`, `SSH_KEY`, `VPS_*`, `DESIRED_PATH_URL`, `NAMECHEAP_URL`, `FIREBASE_SERVICE_ACCOUNT`, or `FIREBASE_SERVICE_ACCOUNT_PATH` inside `TOKKI_ENV`.
+`TOKKI_ENV`에는 앱 실행에 필요한 환경변수만 넣는다. `HOST`, `USERNAME`, `SSH_KEY`, `VPS_*`, `DESIRED_PATH_URL`, `NAMECHEAP_URL`, `FIREBASE_SERVICE_ACCOUNT`, `FIREBASE_SERVICE_ACCOUNT_PATH` 같은 배포 연결 정보나 파일 경로는 넣지 않는다.
 
-## TOKKI_ENV Contents
+## TOKKI_ENV 구성
 
-`TOKKI_ENV` should contain only app runtime keys, including:
+`TOKKI_ENV`에는 아래 범주의 키만 포함한다.
 
-- MySQL keys: `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_DATABASE`, `MYSQL_USERNAME`, `MYSQL_PASSWORD`, `MYSQL_SSL_MODE`.
-- Spring datasource keys: `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`, `SPRING_JPA_HIBERNATE_DDL_AUTO`.
-- Auth keys: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `JWT_SECRET`, `JWT_EXPIRATION`, `ADMIN_SECRET_KEY`.
-- Frontend URLs and Firebase web keys: `VITE_API_BASE_URL`, `VITE_FIREBASE_*`.
-- Firebase Admin env keys: `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`.
+- MySQL: `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_DATABASE`, `MYSQL_USERNAME`, `MYSQL_PASSWORD`, `MYSQL_SSL_MODE`.
+- Spring datasource: `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`, `SPRING_JPA_HIBERNATE_DDL_AUTO`.
+- 인증: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `JWT_SECRET`, `JWT_EXPIRATION`, `ADMIN_SECRET_KEY`.
+- 프론트엔드 및 Firebase Web SDK: `VITE_API_BASE_URL`, `VITE_FIREBASE_*`.
+- Firebase Admin SDK: `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`.
 
-Leave unknown values empty in local `.env` until the current value is shared through Discord.
+Codex가 알 수 없는 값은 비워둔다. 실제 값은 Discord로 전달받은 뒤 로컬 `.env` 또는 GitHub Secrets에만 입력한다.
 
-## Firebase Admin Credentials
+## Firebase Admin SDK
 
-Preferred production format is env-based:
+운영 배포와 로컬 실행 모두 JSON 파일을 추가로 전달하지 않고 환경변수 기반 설정을 사용한다.
 
-- `FIREBASE_PROJECT_ID`: service-account JSON `project_id`.
-- `FIREBASE_CLIENT_EMAIL`: service-account JSON `client_email`.
-- `FIREBASE_PRIVATE_KEY`: service-account JSON `private_key`.
+- `FIREBASE_PROJECT_ID`: 서비스 계정 JSON의 `project_id`.
+- `FIREBASE_CLIENT_EMAIL`: 서비스 계정 JSON의 `client_email`.
+- `FIREBASE_PRIVATE_KEY`: 서비스 계정 JSON의 `private_key`.
 
-Keep newline escapes in `FIREBASE_PRIVATE_KEY` as `\n` inside `.env`/`TOKKI_ENV`. The backend normalizes them at runtime.
+`.env`와 `TOKKI_ENV` 안의 `FIREBASE_PRIVATE_KEY`는 줄바꿈을 `\n` 형태로 보관한다. 백엔드는 실행 시 이를 실제 줄바꿈으로 변환한다.
 
-Do not use `FIREBASE_SERVICE_ACCOUNT_PATH` in CI/CD unless the JSON file is also provisioned on the VPS by a separate secure process. Local development may still use `FIREBASE_SERVICE_ACCOUNT_PATH` with an ignored local JSON file.
-
-## Local Cleanup Checklist
-
-After importing secrets into local `.env` or GitHub Secrets:
-
-1. Delete `.env.cicd`.
-2. Delete local SSH key files such as `*.pem` and `*.pub`.
-3. Delete Firebase service-account JSON files.
-4. Run `git status --short` and confirm only intended tracked docs/config changes remain.
-5. Run a secret scan before opening a PR.
+`FIREBASE_SERVICE_ACCOUNT_PATH`는 사용하지 않는다. Firebase 서비스 계정 JSON을 받은 경우 위 세 값으로 변환해 `.env` 또는 `TOKKI_ENV`에 넣고, JSON 파일 자체는 저장소와 배포 서버에 남기지 않는다.

--- a/docs/secret_guides.md
+++ b/docs/secret_guides.md
@@ -1,0 +1,48 @@
+# TOKKI Secret Guide
+
+Secrets are distributed out of band through Discord. Do not commit `.env`, `.env.cicd`, Firebase service-account JSON files, `.pem`, `.pub`, or private key material.
+
+## GitHub Secrets
+
+Use these repository secrets for deployment transport only:
+
+- `HOST`: VPS public host or IP.
+- `USERNAME`: SSH user for the VPS.
+- `SSH_KEY`: private SSH key for deployment.
+- `TOKKI_ENV`: full production app runtime `.env` content.
+
+Do not place `HOST`, `USERNAME`, `SSH_KEY`, `VPS_*`, `DESIRED_PATH_URL`, `NAMECHEAP_URL`, `FIREBASE_SERVICE_ACCOUNT`, or `FIREBASE_SERVICE_ACCOUNT_PATH` inside `TOKKI_ENV`.
+
+## TOKKI_ENV Contents
+
+`TOKKI_ENV` should contain only app runtime keys, including:
+
+- MySQL keys: `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_DATABASE`, `MYSQL_USERNAME`, `MYSQL_PASSWORD`, `MYSQL_SSL_MODE`.
+- Spring datasource keys: `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`, `SPRING_JPA_HIBERNATE_DDL_AUTO`.
+- Auth keys: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `JWT_SECRET`, `JWT_EXPIRATION`, `ADMIN_SECRET_KEY`.
+- Frontend URLs and Firebase web keys: `VITE_API_BASE_URL`, `VITE_FIREBASE_*`.
+- Firebase Admin env keys: `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`.
+
+Leave unknown values empty in local `.env` until the current value is shared through Discord.
+
+## Firebase Admin Credentials
+
+Preferred production format is env-based:
+
+- `FIREBASE_PROJECT_ID`: service-account JSON `project_id`.
+- `FIREBASE_CLIENT_EMAIL`: service-account JSON `client_email`.
+- `FIREBASE_PRIVATE_KEY`: service-account JSON `private_key`.
+
+Keep newline escapes in `FIREBASE_PRIVATE_KEY` as `\n` inside `.env`/`TOKKI_ENV`. The backend normalizes them at runtime.
+
+Do not use `FIREBASE_SERVICE_ACCOUNT_PATH` in CI/CD unless the JSON file is also provisioned on the VPS by a separate secure process. Local development may still use `FIREBASE_SERVICE_ACCOUNT_PATH` with an ignored local JSON file.
+
+## Local Cleanup Checklist
+
+After importing secrets into local `.env` or GitHub Secrets:
+
+1. Delete `.env.cicd`.
+2. Delete local SSH key files such as `*.pem` and `*.pub`.
+3. Delete Firebase service-account JSON files.
+4. Run `git status --short` and confirm only intended tracked docs/config changes remain.
+5. Run a secret scan before opening a PR.


### PR DESCRIPTION
## Summary
- Normalize .env.example around app-runtime keys and env-based Firebase Admin credentials.
- Harden deploy workflow validation so TOKKI_ENV rejects deployment-only keys and service-account file paths.
- Expand .gitignore for local env, SSH key, and Firebase service-account artifacts.
- Add docs/secret_guides.md in Korean for Discord-based secret distribution.
- Remove Firebase service-account JSON path loading from backend runtime; Firebase Admin now uses env keys only.

## Local cleanup performed
- Imported the Firebase service-account JSON into local .env as env-based Firebase Admin keys.
- Removed local .env.cicd, .pem, .pub, and Firebase service-account JSON artifacts after import.
- Kept .env local-only and ignored.

## Secret safety checks
- git check-ignore confirms .env and removed secret artifact patterns are ignored.
- rg found no remaining local .env.cicd/.pem/.pub/Firebase JSON artifacts.
- staged diff secret-pattern scans returned no matches before commits.
- ./gradlew.bat :backend:test --tests com.tokki.config.FirebaseConfigTest
- ./gradlew.bat :backend:compileJava