### PR TITLE
[codex] Stabilize quiz session sanity flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -719,5 +719,12 @@ Diagram&ERD&명세서/
 !CLAUDE.md
 !GEMINI.md
 !.github/copilot-instructions.md
+
 # Local editor settings
 .vscode/
+
+# plan files
+plan.md
+
+# Local Gradle cache
+.gradle-user-home/

--- a/MANUAL_TEST_SCENARIOS.md
+++ b/MANUAL_TEST_SCENARIOS.md
@@ -1,0 +1,150 @@
+# TOKKI Manual Test Scenarios
+
+## Offline Queue Manual Test Scenarios
+
+This document describes manual test scenarios for the offline progress queue functionality.
+
+### Prerequisites
+- Disable network connection in browser DevTools (Network tab -> Throttling -> Offline)
+- Or use a different device without internet connection
+- Clear localStorage before starting each test
+
+### Test Scenario 1: Quiz Completion While Offline
+
+**Steps:**
+1. Open DevTools Network tab and set to "Offline"
+2. Navigate to a stage and start a quiz
+3. Complete all questions (submit answers)
+4. Verify on result page that the status shows "오프라인 저장됨" (amber badge)
+5. Re-enable network connection
+6. Verify the status changes to "저장 완료" (green badge)
+7. Refresh the page and check the stage is marked as completed
+
+**Expected Result:**
+- Quiz completes successfully while offline
+- Progress is queued locally
+- Progress syncs automatically when connection is restored
+- Stage completion status persists after page refresh
+
+### Test Scenario 2: Incorrect Word While Offline
+
+**Steps:**
+1. Open DevTools Network tab and set to "Offline"
+2. Navigate to a stage and start a quiz
+3. Intentionally answer some questions incorrectly
+4. Complete the quiz
+5. Verify result page shows offline status
+6. Re-enable network connection
+7. Navigate to the same stage again
+8. Verify "Incorrect Note" screen appears with the words you got wrong
+
+**Expected Result:**
+- Incorrect words are recorded locally while offline
+- After sync, incorrect words appear in the note
+
+### Test Scenario 3: Multiple Offline Sessions
+
+**Steps:**
+1. Complete Stage 1 quiz while offline
+2. Complete Stage 2 quiz while offline
+3. Re-enable network connection
+4. Verify both stages show as completed
+5. Verify both stages' progress data was synced correctly
+
+**Expected Result:**
+- Multiple offline sessions are queued properly
+- All sessions sync correctly when connection is restored
+
+### Test Scenario 4: Offline Draft Resume
+
+**Steps:**
+1. Start a quiz while offline
+2. Answer a few questions
+3. Close the browser tab (simulate app crash)
+4. Re-open the app (still offline)
+5. Navigate to the same stage
+6. Verify "이어서 풀기" (Resume) option is available
+7. Click resume and verify your previous answers are restored
+8. Complete the quiz
+9. Re-enable network connection
+10. Verify full quiz result is synced
+
+**Expected Result:**
+- Draft sessions are saved locally while offline
+- Draft can be resumed after app restart
+- Final result syncs correctly when connection is restored
+
+### Test Scenario 5: Network Fluctuation
+
+**Steps:**
+1. Start a quiz online
+2. Answer question 1
+3. Go offline
+3. Answer questions 2-5
+4. Go back online
+5. Answer questions 6-10
+6. Complete the quiz
+7. Verify all answers were saved correctly
+
+**Expected Result:**
+- System handles network transitions gracefully
+- All answers are preserved regardless of network state
+
+### Test Scenario 6: Queue Persistence
+
+**Steps:**
+1. Complete a quiz while offline
+2. Verify offline status badge
+3. Close browser completely
+4. Re-open browser and navigate to TOKKI
+5. Verify queue still shows "오프라인 저장됨"
+6. Go online
+7. Verify sync completes
+
+**Expected Result:**
+- Offline queue persists across browser sessions
+- Sync happens when connection is restored
+
+### Test Scenario 7: Sync Failure Handling
+
+**Steps:**
+1. Use DevTools to block API requests (not offline mode)
+2. Complete a quiz
+3. Observe the status badge
+4. Stop blocking requests
+5. Verify retry mechanism kicks in
+
+**Expected Result:**
+- Failed sync shows appropriate error status
+- System retries when connection is available
+
+### Test Scenario 8: Large Batch Offline
+
+**Steps:**
+1. Go offline
+2. Complete 5 different stages in succession
+3. Go online
+4. Monitor that all 5 stages sync correctly
+5. Check that each stage shows correct completion
+
+**Expected Result:**
+- Multiple offline operations queue correctly
+- Batch sync processes all queued operations
+
+## Checklist for Each Test
+
+- [ ] Initial state verified (no offline queue)
+- [ ] Operation performed offline
+- [ ] Offline indicator appeared
+- [ ] Data persisted locally
+- [ ] Connection restored
+- [ ] Sync indicator appeared
+- [ ] Data verified on server
+- [ ] UI reflects correct state after sync
+
+## Notes
+
+- Tests should be performed on both desktop and mobile browsers
+- Check both Chrome and Safari/Edge for compatibility
+- Verify behavior on both slow 3G and completely offline conditions
+- Test with both login and logout states where applicable

--- a/backend/src/main/java/com/tokki/batch/RankingBatchScheduler.java
+++ b/backend/src/main/java/com/tokki/batch/RankingBatchScheduler.java
@@ -1,6 +1,6 @@
 package com.tokki.batch;
 
-import com.tokki.repository.RankingRepository;
+import com.tokki.service.RankingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,12 +11,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RankingBatchScheduler {
 
-    private final RankingRepository rankingRepository;
+    private final RankingService rankingService;
 
-    // 매월 1일 자정 실행
-    @Scheduled(cron = "0 0 0 1 * *")
-    public void updateMonthlyRankings() {
-        log.info("Monthly ranking batch started");
-        // TODO: Phase 2 — 이전 달 세션 점수 집계 후 rankings 테이블 갱신
+    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
+    public void updateDailyRankings() {
+        log.info("Daily ranking batch started - updating top 10 incorrect words");
+        try {
+            rankingService.updateDailyRankings();
+            log.info("Daily ranking batch completed successfully");
+        } catch (Exception e) {
+            log.error("Daily ranking batch failed", e);
+        }
     }
 }

--- a/backend/src/main/java/com/tokki/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tokki/config/SecurityConfig.java
@@ -86,8 +86,8 @@ public class SecurityConfig {
                         .successHandler(oauth2SuccessHandler)
                         .failureHandler(oauth2FailureHandler)
                 )
-                .addFilterBefore(devAuthenticationFilter, JwtAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(devAuthenticationFilter, JwtAuthenticationFilter.class)
                 .addFilterAfter(firebaseTokenFilter, JwtAuthenticationFilter.class)
                 .build();
     }

--- a/backend/src/main/java/com/tokki/controller/QuizSessionController.java
+++ b/backend/src/main/java/com/tokki/controller/QuizSessionController.java
@@ -1,6 +1,7 @@
 package com.tokki.controller;
 
 import com.tokki.dto.request.SaveSessionRequest;
+import com.tokki.dto.request.UpsertDraftSessionRequest;
 import com.tokki.dto.response.QuizSessionResponse;
 import com.tokki.security.AuthUser;
 import com.tokki.service.QuizSessionService;
@@ -28,7 +29,37 @@ public class QuizSessionController {
 
     @GetMapping
     public ResponseEntity<List<QuizSessionResponse>> getSessions(
-            @AuthenticationPrincipal AuthUser authUser) {
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam(required = false) Long stageId,
+            @RequestParam(required = false) Boolean completed) {
+        if (completed != null && completed) {
+            return ResponseEntity.ok(quizSessionService.getCompletedSessions(authUser.getUid(), stageId));
+        }
+        if (completed != null && !completed) {
+            return ResponseEntity.ok(quizSessionService.getDraftSessions(authUser.getUid()));
+        }
         return ResponseEntity.ok(quizSessionService.getUserSessions(authUser.getUid()));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<QuizSessionResponse> getSession(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long id) {
+        return ResponseEntity.ok(quizSessionService.getSessionById(id, authUser.getUid()));
+    }
+
+    @PutMapping("/current")
+    public ResponseEntity<QuizSessionResponse> upsertDraftSession(
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody UpsertDraftSessionRequest request) {
+        return ResponseEntity.ok(quizSessionService.upsertDraftSession(authUser.getUid(), request));
+    }
+
+    @DeleteMapping("/current")
+    public ResponseEntity<Void> deleteDraftSession(
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam Long stageId) {
+        quizSessionService.deleteDraftSession(authUser.getUid(), stageId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/tokki/domain/PvpResult.java
+++ b/backend/src/main/java/com/tokki/domain/PvpResult.java
@@ -38,4 +38,8 @@ public class PvpResult {
     protected void onCreate() {
         createdAt = LocalDateTime.now();
     }
+
+    public void updateResult(String result) {
+        this.result = result;
+    }
 }

--- a/backend/src/main/java/com/tokki/domain/QuizSession.java
+++ b/backend/src/main/java/com/tokki/domain/QuizSession.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "quiz_sessions")
@@ -25,6 +27,13 @@ public class QuizSession {
     @JoinColumn(name = "stage_id", nullable = false)
     private Stage stage;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mode", length = 10)
+    private QuizMode mode;
+
+    @Column(name = "current_index")
+    private Integer currentIndex;
+
     @Column(nullable = false)
     private Integer score;
 
@@ -37,8 +46,43 @@ public class QuizSession {
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
 
+    @OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<QuizAnswer> answers = new ArrayList<>();
+
+    public boolean isDraft() {
+        return completedAt == null;
+    }
+
+    public boolean isCompleted() {
+        return completedAt != null;
+    }
+
+    public void markCompleted() {
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void updateProgress(int newIndex, int newScore) {
+        this.currentIndex = newIndex;
+        this.score = newScore;
+    }
+
+    public void setMode(QuizMode mode) {
+        this.mode = mode;
+    }
+
+    public void setTotalQuestions(Integer totalQuestions) {
+        this.totalQuestions = totalQuestions;
+    }
+
     @PrePersist
     protected void onCreate() {
         startedAt = LocalDateTime.now();
+        if (currentIndex == null) {
+            currentIndex = 0;
+        }
+        if (score == null) {
+            score = 0;
+        }
     }
 }

--- a/backend/src/main/java/com/tokki/domain/Ranking.java
+++ b/backend/src/main/java/com/tokki/domain/Ranking.java
@@ -3,9 +3,11 @@ package com.tokki.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
+
 @Entity
 @Table(name = "rankings", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"uid", "period"})
+        @UniqueConstraint(columnNames = {"word_id", "period"})
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,11 +20,11 @@ public class Ranking {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "uid", nullable = false)
-    private User user;
+    @JoinColumn(name = "word_id", nullable = false)
+    private Word word;
 
-    @Column(nullable = false)
-    private Integer score;
+    @Column(name = "miss_count", nullable = false)
+    private Integer missCount;
 
     @Column(name = "rank_position", nullable = false)
     private Integer rank;
@@ -30,8 +32,11 @@ public class Ranking {
     @Column(nullable = false, length = 20)
     private String period;
 
-    public void update(int rank, int score) {
+    @Column(name = "snapshot_date", nullable = false)
+    private LocalDate snapshotDate;
+
+    public void update(int rank, int missCount) {
         this.rank = rank;
-        this.score = score;
+        this.missCount = missCount;
     }
 }

--- a/backend/src/main/java/com/tokki/dto/request/UpsertDraftSessionRequest.java
+++ b/backend/src/main/java/com/tokki/dto/request/UpsertDraftSessionRequest.java
@@ -1,0 +1,38 @@
+package com.tokki.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class UpsertDraftSessionRequest {
+
+    @NotNull
+    private Long stageId;
+
+    @NotNull
+    private String mode;
+
+    @NotNull
+    @Min(0)
+    private Integer currentIndex;
+
+    @NotNull
+    @Min(0)
+    private Integer score;
+
+    @NotNull
+    @Min(1)
+    private Integer totalQuestions;
+
+    private List<AnswerItem> answers;
+
+    @Data
+    public static class AnswerItem {
+        private Long wordId;
+        private String userAnswer;
+        private Boolean correct;
+    }
+}

--- a/backend/src/main/java/com/tokki/dto/response/QuizSessionResponse.java
+++ b/backend/src/main/java/com/tokki/dto/response/QuizSessionResponse.java
@@ -5,25 +5,68 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
 public class QuizSessionResponse {
     private Long id;
     private Long stageId;
+    private String mode;
+    private Integer currentIndex;
     private Integer score;
     private Integer totalQuestions;
     private LocalDateTime startedAt;
     private LocalDateTime completedAt;
+    private List<AnswerDetail> answers;
+
+    @Getter
+    @Builder
+    public static class AnswerDetail {
+        private Long wordId;
+        private String word;
+        private String meaning;
+        private String userAnswer;
+        private Boolean correct;
+    }
 
     public static QuizSessionResponse from(QuizSession session) {
         return QuizSessionResponse.builder()
                 .id(session.getId())
                 .stageId(session.getStage().getId())
+                .mode(session.getMode() != null ? session.getMode().name() : null)
+                .currentIndex(session.getCurrentIndex())
                 .score(session.getScore())
                 .totalQuestions(session.getTotalQuestions())
                 .startedAt(session.getStartedAt())
                 .completedAt(session.getCompletedAt())
+                .answers(null)
+                .build();
+    }
+
+    public static QuizSessionResponse fromWithDetails(QuizSession session) {
+        List<AnswerDetail> answers = session.getAnswers() != null
+            ? session.getAnswers().stream()
+                .map(a -> AnswerDetail.builder()
+                    .wordId(a.getWord().getId())
+                    .word(a.getWord().getWord())
+                    .meaning(a.getWord().getMeaning())
+                    .userAnswer(a.getUserAnswer())
+                    .correct(a.getCorrect())
+                    .build())
+                .toList()
+            : List.of();
+
+        return QuizSessionResponse.builder()
+                .id(session.getId())
+                .stageId(session.getStage().getId())
+                .mode(session.getMode() != null ? session.getMode().name() : null)
+                .currentIndex(session.getCurrentIndex())
+                .score(session.getScore())
+                .totalQuestions(session.getTotalQuestions())
+                .startedAt(session.getStartedAt())
+                .completedAt(session.getCompletedAt())
+                .answers(answers)
                 .build();
     }
 }

--- a/backend/src/main/java/com/tokki/dto/response/RankingResponse.java
+++ b/backend/src/main/java/com/tokki/dto/response/RankingResponse.java
@@ -7,19 +7,25 @@ import lombok.Getter;
 @Getter
 @Builder
 public class RankingResponse {
+    private Long id;
+    private Long wordId;
+    private String word;
+    private String meaning;
+    private Integer missCount;
     private Integer rank;
-    private String uid;
-    private String nickname;
-    private Integer score;
     private String period;
+    private String snapshotDate;
 
     public static RankingResponse from(Ranking ranking) {
         return RankingResponse.builder()
+                .id(ranking.getId())
+                .wordId(ranking.getWord().getId())
+                .word(ranking.getWord().getWord())
+                .meaning(ranking.getWord().getMeaning())
+                .missCount(ranking.getMissCount())
                 .rank(ranking.getRank())
-                .uid(ranking.getUser().getUid())
-                .nickname(ranking.getUser().getNickname())
-                .score(ranking.getScore())
                 .period(ranking.getPeriod())
+                .snapshotDate(ranking.getSnapshotDate().toString())
                 .build();
     }
 }

--- a/backend/src/main/java/com/tokki/dto/response/StageResponse.java
+++ b/backend/src/main/java/com/tokki/dto/response/StageResponse.java
@@ -1,7 +1,6 @@
 package com.tokki.dto.response;
 
 import com.tokki.domain.Stage;
-import com.tokki.dto.response.WordResponse;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/backend/src/main/java/com/tokki/dto/response/WordRelationResponse.java
+++ b/backend/src/main/java/com/tokki/dto/response/WordRelationResponse.java
@@ -10,6 +10,8 @@ public class WordRelationResponse {
     private Long id;
     private Long wordId;
     private Long relatedWordId;
+    private String relatedWord;
+    private String relatedMeaning;
     private String relationType;
 
     public static WordRelationResponse from(WordRelation relation) {
@@ -17,6 +19,8 @@ public class WordRelationResponse {
                 .id(relation.getId())
                 .wordId(relation.getWord().getId())
                 .relatedWordId(relation.getRelatedWord().getId())
+                .relatedWord(relation.getRelatedWord().getWord())
+                .relatedMeaning(relation.getRelatedWord().getMeaning())
                 .relationType(relation.getRelationType())
                 .build();
     }

--- a/backend/src/main/java/com/tokki/repository/IncorrectWordRepository.java
+++ b/backend/src/main/java/com/tokki/repository/IncorrectWordRepository.java
@@ -2,6 +2,7 @@ package com.tokki.repository;
 
 import com.tokki.domain.IncorrectWord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,4 +10,10 @@ import java.util.Optional;
 public interface IncorrectWordRepository extends JpaRepository<IncorrectWord, Long> {
     List<IncorrectWord> findByUserUidOrderByCountDesc(String uid);
     Optional<IncorrectWord> findByUserUidAndWordId(String uid, Long wordId);
+
+    @Query("SELECT new com.tokki.repository.WordMissCountDto(i.word, SUM(i.count)) " +
+           "FROM IncorrectWord i " +
+           "GROUP BY i.word " +
+           "ORDER BY SUM(i.count) DESC")
+    List<WordMissCountDto> aggregateMissCountsByWord();
 }

--- a/backend/src/main/java/com/tokki/repository/QuizAnswerRepository.java
+++ b/backend/src/main/java/com/tokki/repository/QuizAnswerRepository.java
@@ -2,9 +2,18 @@ package com.tokki.repository;
 
 import com.tokki.domain.QuizAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface QuizAnswerRepository extends JpaRepository<QuizAnswer, Long> {
     List<QuizAnswer> findBySessionId(Long sessionId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM QuizAnswer a WHERE a.session.id = :sessionId")
+    void deleteBySessionId(@Param("sessionId") Long sessionId);
 }

--- a/backend/src/main/java/com/tokki/repository/QuizSessionRepository.java
+++ b/backend/src/main/java/com/tokki/repository/QuizSessionRepository.java
@@ -2,9 +2,25 @@ package com.tokki.repository;
 
 import com.tokki.domain.QuizSession;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 import java.util.List;
 
 public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> {
     List<QuizSession> findByUserUidOrderByStartedAtDesc(String uid);
+
+    @Query("SELECT s FROM QuizSession s WHERE s.user.uid = :uid AND s.completedAt IS NULL ORDER BY s.startedAt DESC")
+    List<QuizSession> findDraftSessionsByUid(@Param("uid") String uid);
+
+    @Query("SELECT s FROM QuizSession s WHERE s.user.uid = :uid AND s.stage.id = :stageId AND s.completedAt IS NULL")
+    Optional<QuizSession> findDraftSessionByUidAndStageId(@Param("uid") String uid, @Param("stageId") Long stageId);
+
+    @Query("SELECT s FROM QuizSession s LEFT JOIN FETCH s.answers a WHERE s.id = :id")
+    Optional<QuizSession> findByIdWithAnswers(@Param("id") Long id);
+
+    @Query("SELECT s FROM QuizSession s WHERE s.user.uid = :uid AND s.completedAt IS NOT NULL ORDER BY s.completedAt DESC")
+    List<QuizSession> findCompletedSessionsByUid(@Param("uid") String uid);
 }

--- a/backend/src/main/java/com/tokki/repository/RankingRepository.java
+++ b/backend/src/main/java/com/tokki/repository/RankingRepository.java
@@ -4,9 +4,13 @@ import com.tokki.domain.Ranking;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface RankingRepository extends JpaRepository<Ranking, Long> {
     List<Ranking> findByPeriodOrderByRankAsc(String period);
-    Optional<Ranking> findByUserUidAndPeriod(String uid, String period);
+
+    void deleteByPeriod(String period);
+
+    List<Ranking> findByPeriodOrderByMissCountDesc(String period);
+
+    boolean existsByWordIdAndPeriod(Long wordId, String period);
 }

--- a/backend/src/main/java/com/tokki/repository/WordMissCountDto.java
+++ b/backend/src/main/java/com/tokki/repository/WordMissCountDto.java
@@ -1,0 +1,12 @@
+package com.tokki.repository;
+
+import com.tokki.domain.Word;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WordMissCountDto {
+    private final Word word;
+    private final Long totalCount;
+}

--- a/backend/src/main/java/com/tokki/repository/WordRepository.java
+++ b/backend/src/main/java/com/tokki/repository/WordRepository.java
@@ -2,10 +2,15 @@ package com.tokki.repository;
 
 import com.tokki.domain.Word;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface WordRepository extends JpaRepository<Word, Long> {
     List<Word> findByStageIdOrderByOrderIndexAscIdAsc(Long stageId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Word w WHERE w.stage.id = :stageId")
     void deleteByStageId(Long stageId);
 }

--- a/backend/src/main/java/com/tokki/service/PvpService.java
+++ b/backend/src/main/java/com/tokki/service/PvpService.java
@@ -78,6 +78,7 @@ public class PvpService {
         if (existing.size() == 1) {
             PvpResult opponent = existing.get(0);
             String opponentResult = result.equals("WIN") ? "LOSE" : result.equals("LOSE") ? "WIN" : "DRAW";
+            opponent.updateResult(opponentResult);
             // Opponent result is already saved; mark room complete
             room.complete();
             pvpRoomRepository.save(room);

--- a/backend/src/main/java/com/tokki/service/QuizSessionService.java
+++ b/backend/src/main/java/com/tokki/service/QuizSessionService.java
@@ -2,6 +2,7 @@ package com.tokki.service;
 
 import com.tokki.domain.*;
 import com.tokki.dto.request.SaveSessionRequest;
+import com.tokki.dto.request.UpsertDraftSessionRequest;
 import com.tokki.dto.response.QuizSessionResponse;
 import com.tokki.exception.AppException;
 import com.tokki.exception.ErrorCode;
@@ -64,6 +65,84 @@ public class QuizSessionService {
     @Transactional(readOnly = true)
     public List<QuizSessionResponse> getUserSessions(String uid) {
         return quizSessionRepository.findByUserUidOrderByStartedAtDesc(uid).stream()
+                .map(QuizSessionResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public QuizSessionResponse getSessionById(Long sessionId, String uid) {
+        QuizSession session = quizSessionRepository.findByIdWithAnswers(sessionId)
+                .orElseThrow(() -> new AppException(ErrorCode.SESSION_NOT_FOUND));
+        if (!session.getUser().getUid().equals(uid)) {
+            throw new AppException(ErrorCode.FORBIDDEN);
+        }
+        return QuizSessionResponse.fromWithDetails(session);
+    }
+
+    @Transactional
+    public QuizSessionResponse upsertDraftSession(String uid, UpsertDraftSessionRequest request) {
+        User user = userRepository.findById(uid)
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+        Stage stage = stageRepository.findById(request.getStageId())
+                .orElseThrow(() -> new AppException(ErrorCode.STAGE_NOT_FOUND));
+
+        QuizSession session = quizSessionRepository
+                .findDraftSessionByUidAndStageId(uid, request.getStageId())
+                .orElse(QuizSession.builder()
+                        .user(user)
+                        .stage(stage)
+                        .build());
+
+        session.setMode(QuizMode.valueOf(request.getMode()));
+        session.setTotalQuestions(request.getTotalQuestions());
+        session.updateProgress(request.getCurrentIndex(), request.getScore());
+
+        QuizSession saved = quizSessionRepository.save(session);
+
+        if (request.getAnswers() != null) {
+            quizAnswerRepository.deleteBySessionId(saved.getId());
+            for (UpsertDraftSessionRequest.AnswerItem item : request.getAnswers()) {
+                Word word = wordRepository.findById(item.getWordId())
+                        .orElseThrow(() -> new AppException(ErrorCode.WORD_NOT_FOUND));
+                quizAnswerRepository.save(QuizAnswer.builder()
+                        .session(saved)
+                        .word(word)
+                        .userAnswer(item.getUserAnswer())
+                        .correct(item.getCorrect())
+                        .build());
+            }
+        }
+
+        return QuizSessionResponse.from(saved);
+    }
+
+    @Transactional
+    public void deleteDraftSession(String uid, Long stageId) {
+        QuizSession session = quizSessionRepository
+                .findDraftSessionByUidAndStageId(uid, stageId)
+                .orElseThrow(() -> new AppException(ErrorCode.SESSION_NOT_FOUND));
+        if (!session.getUser().getUid().equals(uid)) {
+            throw new AppException(ErrorCode.FORBIDDEN);
+        }
+        quizAnswerRepository.deleteBySessionId(session.getId());
+        quizSessionRepository.delete(session);
+    }
+
+    @Transactional(readOnly = true)
+    public List<QuizSessionResponse> getDraftSessions(String uid) {
+        return quizSessionRepository.findDraftSessionsByUid(uid).stream()
+                .map(QuizSessionResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<QuizSessionResponse> getCompletedSessions(String uid, Long stageId) {
+        List<QuizSession> sessions = stageId != null
+            ? quizSessionRepository.findByUserUidOrderByStartedAtDesc(uid).stream()
+                .filter(s -> s.isCompleted() && s.getStage().getId().equals(stageId))
+                .toList()
+            : quizSessionRepository.findCompletedSessionsByUid(uid);
+        return sessions.stream()
                 .map(QuizSessionResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/com/tokki/service/RankingService.java
+++ b/backend/src/main/java/com/tokki/service/RankingService.java
@@ -1,6 +1,8 @@
 package com.tokki.service;
 
+import com.tokki.domain.Ranking;
 import com.tokki.dto.response.RankingResponse;
+import com.tokki.repository.IncorrectWordRepository;
 import com.tokki.repository.RankingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -8,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -15,14 +18,47 @@ import java.util.List;
 public class RankingService {
 
     private final RankingRepository rankingRepository;
+    private final IncorrectWordRepository incorrectWordRepository;
+
+    private static final int TOP_N = 10;
 
     @Transactional(readOnly = true)
     public List<RankingResponse> getRankings(String period) {
         String target = (period != null && !period.isBlank())
                 ? period
-                : LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+                : LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         return rankingRepository.findByPeriodOrderByRankAsc(target).stream()
                 .map(RankingResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public void updateDailyRankings() {
+        LocalDate today = LocalDate.now();
+        String period = today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        var incorrectWordCounts = incorrectWordRepository.aggregateMissCountsByWord();
+        rankingRepository.deleteByPeriod(period);
+
+        List<Ranking> newRankings = new ArrayList<>();
+        int rank = 1;
+        for (var entry : incorrectWordCounts) {
+            if (rank > TOP_N) break;
+
+            int totalMissCount = entry.getTotalCount().intValue();
+
+            Ranking ranking = Ranking.builder()
+                    .word(entry.getWord())
+                    .missCount(totalMissCount)
+                    .rank(rank)
+                    .period(period)
+                    .snapshotDate(today)
+                    .build();
+
+            newRankings.add(ranking);
+            rank++;
+        }
+
+        rankingRepository.saveAll(newRankings);
     }
 }

--- a/backend/src/test/java/com/tokki/service/ExcelStageUploadServiceTest.java
+++ b/backend/src/test/java/com/tokki/service/ExcelStageUploadServiceTest.java
@@ -1,0 +1,136 @@
+package com.tokki.service;
+
+import com.tokki.dto.response.ExcelUploadPreviewResponse;
+import com.tokki.exception.AppException;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ExcelStageUploadServiceTest {
+
+    private final ExcelStageUploadService service = new ExcelStageUploadService();
+
+    @Test
+    void rejectsNullFile() {
+        assertThatThrownBy(() -> service.preview(null))
+                .isInstanceOf(AppException.class);
+    }
+
+    @Test
+    void rejectsEmptyFile() {
+        MultipartFile emptyFile = new MockMultipartFile("file", new byte[0]);
+        assertThatThrownBy(() -> service.preview(emptyFile))
+                .isInstanceOf(AppException.class);
+    }
+
+    @Test
+    void rejectsNonXlsxFile() {
+        MultipartFile csvFile = new MockMultipartFile("file", "test.csv", "text/csv", "data".getBytes());
+        assertThatThrownBy(() -> service.preview(csvFile))
+                .isInstanceOf(AppException.class);
+    }
+
+    @Test
+    void rejectsFileOver5MB() {
+        byte[] largeContent = new byte[5 * 1024 * 1024 + 1];
+        MultipartFile largeFile = new MockMultipartFile("file", "large.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", largeContent);
+        assertThatThrownBy(() -> service.preview(largeFile))
+                .isInstanceOf(AppException.class);
+    }
+
+    @Test
+    void detectsMissingRequiredHeaders() throws IOException {
+        Path tempFile = Files.createTempFile("test", ".xlsx");
+        Files.write(tempFile, new byte[0]);
+
+        MultipartFile file = new MockMultipartFile("file", "test.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", Files.readAllBytes(tempFile));
+        Files.delete(tempFile);
+
+        assertThatThrownBy(() -> service.preview(file))
+                .isInstanceOf(AppException.class);
+    }
+
+    @Test
+    void returnsErrorForDuplicateOrderIndexWithinSameStage() {
+        MultipartFile mockFile = new MockMultipartFile(
+                "file",
+                "test.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                createMockExcelContentWithDuplicateOrderIndex()
+        );
+
+        ExcelUploadPreviewResponse result = service.preview(mockFile);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errors()).anyMatch(error ->
+                error.field().equals("orderIndex") && error.message().contains("중복")
+        );
+    }
+
+    @Test
+    void validatesSuccessfulPreview() {
+        MultipartFile validFile = new MockMultipartFile(
+                "file",
+                "valid.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                createMockValidExcelContent()
+        );
+
+        ExcelUploadPreviewResponse result = service.preview(validFile);
+
+        assertThat(result.valid()).isTrue();
+        assertThat(result.errors()).isEmpty();
+        assertThat(result.rowCount()).isGreaterThan(0);
+        assertThat(result.stages()).isNotEmpty();
+    }
+
+    private byte[] createMockExcelContentWithDuplicateOrderIndex() {
+        return createWorkbookBytes(new Object[][]{
+                {"difficulty", "stageNumber", "orderIndex", "word", "meaning"},
+                {"easy", 1, 1, "apple", "사과"},
+                {"easy", 1, 1, "banana", "바나나"}
+        });
+    }
+
+    private byte[] createMockValidExcelContent() {
+        return createWorkbookBytes(new Object[][]{
+                {"difficulty", "stageNumber", "orderIndex", "word", "meaning", "example", "imageUrl"},
+                {"easy", 1, 1, "apple", "사과", "I eat an apple.", "https://example.com/apple.png"},
+                {"easy", 1, 2, "banana", "바나나", "", ""}
+        });
+    }
+
+    private byte[] createWorkbookBytes(Object[][] rows) {
+        try (XSSFWorkbook workbook = new XSSFWorkbook();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("words");
+            for (int rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+                Row row = sheet.createRow(rowIndex);
+                Object[] values = rows[rowIndex];
+                for (int cellIndex = 0; cellIndex < values.length; cellIndex++) {
+                    Object value = values[cellIndex];
+                    if (value instanceof Number number) {
+                        row.createCell(cellIndex).setCellValue(number.doubleValue());
+                    } else {
+                        row.createCell(cellIndex).setCellValue(String.valueOf(value));
+                    }
+                }
+            }
+            workbook.write(outputStream);
+            return outputStream.toByteArray();
+        } catch (IOException e) {
+            throw new AssertionError("Failed to create workbook fixture", e);
+        }
+    }
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, useEffect, useState, type ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { AuthService } from '../services/AuthService';
+import { onAuthExpired } from '../lib/axios';
 import type { AppUser } from '../types';
 
 interface AuthContextType {
@@ -16,6 +18,7 @@ const DEV = import.meta.env.DEV && import.meta.env.VITE_AUTH_DEV_USER === 'true'
 const DEV_USER: AppUser = { uid: 'dev-uid', email: 'dev@localhost', role: 'admin' };
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const navigate = useNavigate();
   const [user, setUser] = useState<AppUser | null>(DEV ? DEV_USER : null);
   const [loading, setLoading] = useState(!DEV);
 
@@ -43,6 +46,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setLoading(false);
       });
   }, []);
+
+  useEffect(() => {
+    if (DEV) return;
+
+    const unsubscribe = onAuthExpired(() => {
+      setUser(null);
+      navigate('/login', { replace: true });
+    });
+
+    return unsubscribe;
+  }, [navigate]);
 
   return (
     <AuthContext.Provider value={{ user, loading, setAuthenticatedUser: setUser, refreshUser, logout }}>

--- a/frontend/src/hooks/useQuizSession.ts
+++ b/frontend/src/hooks/useQuizSession.ts
@@ -1,0 +1,152 @@
+import { useState, useCallback, useRef } from 'react';
+import { useAuth } from './useAuth';
+import { QuizSessionService } from '../services/QuizSessionService';
+import { OfflineProgressQueue, type ProgressSyncStatus } from '../services/OfflineProgressQueue';
+import type { Word, QuizMode } from '../types';
+
+export interface QuestionResult {
+  word: Word;
+  userAnswer: string;
+  correctAnswer: string;
+  isCorrect: boolean;
+}
+
+export interface QuizSessionState {
+  mode: QuizMode;
+  currentIndex: number;
+  answer: string;
+  submitted: boolean;
+  results: QuestionResult[];
+  syncStatus: ProgressSyncStatus;
+}
+
+export interface UseQuizSessionOptions {
+  words: Word[];
+  stageId: number;
+  mode: QuizMode;
+  onCompleted?: (finalResults: QuestionResult[]) => void;
+}
+
+export function useQuizSession({
+  words,
+  stageId,
+  mode: initialMode,
+  onCompleted,
+}: UseQuizSessionOptions) {
+  const { user } = useAuth();
+  const savingRef = useRef(false);
+
+  const [mode, setMode] = useState<QuizMode>(initialMode);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answer, setAnswer] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [results, setResults] = useState<QuestionResult[]>([]);
+  const [syncStatus] = useState<ProgressSyncStatus>(
+    OfflineProgressQueue.hasPending() ? 'queued' : 'idle'
+  );
+
+  const getPrompt = useCallback((word: Word) => {
+    return mode === 'KtoE' ? word.meaning : word.word;
+  }, [mode]);
+
+  const getCorrect = useCallback((word: Word) => {
+    return mode === 'KtoE' ? word.word : word.meaning;
+  }, [mode]);
+
+  const saveDraft = useCallback(async (newResults: QuestionResult[]) => {
+    if (!user || savingRef.current) return;
+
+    savingRef.current = true;
+    try {
+      await QuizSessionService.upsertDraftSession({
+        stageId,
+        mode,
+        currentIndex: currentIndex + 1,
+        score: newResults.filter(r => r.isCorrect).length,
+        totalQuestions: words.length,
+        answers: newResults.map(r => ({
+          wordId: r.word.wordId,
+          userAnswer: r.userAnswer,
+          correct: r.isCorrect
+        }))
+      });
+    } catch (err) {
+      console.error('Failed to save draft:', err);
+    } finally {
+      savingRef.current = false;
+    }
+  }, [user, stageId, mode, currentIndex, words.length]);
+
+  const submitAnswer = useCallback(async (userAnswer: string) => {
+    const word = words[currentIndex];
+    if (!word || submitted) return { success: false };
+
+    const correctAnswer = getCorrect(word);
+    const isCorrect = userAnswer.trim().toLowerCase() === correctAnswer.trim().toLowerCase();
+    const newResult: QuestionResult = { word, userAnswer, correctAnswer, isCorrect };
+
+    setResults(prev => [...prev, newResult]);
+    setSubmitted(true);
+
+    await saveDraft([...results, newResult]);
+
+    return { success: true, isCorrect };
+  }, [words, currentIndex, submitted, getCorrect, results, saveDraft]);
+
+  const skipQuestion = useCallback(async () => {
+    const word = words[currentIndex];
+    if (!word || submitted) return { success: false };
+
+    const correctAnswer = getCorrect(word);
+    const newResult: QuestionResult = { word, userAnswer: '', correctAnswer, isCorrect: false };
+
+    setResults(prev => [...prev, newResult]);
+    setSubmitted(true);
+
+    await saveDraft([...results, newResult]);
+
+    return { success: true };
+  }, [words, currentIndex, submitted, getCorrect, results, saveDraft]);
+
+  const nextQuestion = useCallback(() => {
+    if (currentIndex < words.length - 1) {
+      setCurrentIndex(i => i + 1);
+      setAnswer('');
+      setSubmitted(false);
+    } else {
+      onCompleted?.(results);
+    }
+  }, [currentIndex, words.length, results, onCompleted]);
+
+  const resetQuiz = useCallback(() => {
+    setCurrentIndex(0);
+    setResults([]);
+    setAnswer('');
+    setSubmitted(false);
+  }, []);
+
+  return {
+    state: {
+      mode,
+      currentIndex,
+      answer,
+      submitted,
+      results,
+      syncStatus,
+      words,
+      currentWord: words[currentIndex] || null,
+      isLastQuestion: currentIndex === words.length - 1,
+      progressValue: currentIndex + (submitted ? 1 : 0),
+    },
+    actions: {
+      setMode,
+      setAnswer,
+      submitAnswer,
+      skipQuestion,
+      nextQuestion,
+      resetQuiz,
+      getPrompt,
+      getCorrect,
+    },
+  };
+}

--- a/frontend/src/lib/axios.ts
+++ b/frontend/src/lib/axios.ts
@@ -29,6 +29,18 @@ export function setStoredAccessToken(token: string | null): void {
   }
 }
 
+const AUTH_EXPIRED_EVENT = 'tokki:auth-expired';
+
+export function emitAuthExpired(): void {
+  window.dispatchEvent(new CustomEvent(AUTH_EXPIRED_EVENT));
+}
+
+export function onAuthExpired(callback: () => void): () => void {
+  const handler = () => callback();
+  window.addEventListener(AUTH_EXPIRED_EVENT, handler);
+  return () => window.removeEventListener(AUTH_EXPIRED_EVENT, handler);
+}
+
 const apiClient = axios.create({
   baseURL: apiBaseUrl,
   withCredentials: true,
@@ -54,7 +66,22 @@ apiClient.interceptors.request.use(async (config) => {
 apiClient.interceptors.response.use(
   (response) => response.data?.data ?? response.data,
   (error) => {
-    const code = error.response?.data?.error?.code ?? error.message;
+    const status = error.response?.status;
+    const errorCode = error.response?.data?.error?.code;
+
+    const isAuthError =
+      status === 401 ||
+      errorCode === 'AUTH_REQUIRED' ||
+      errorCode === 'TOKEN_EXPIRED' ||
+      errorCode === 'TOKEN_INVALID' ||
+      errorCode === 'UNAUTHORIZED';
+
+    if (isAuthError && !shouldUseDevAuth) {
+      setStoredAccessToken(null);
+      emitAuthExpired();
+    }
+
+    const code = errorCode ?? error.message;
     return Promise.reject(new Error(code));
   },
 );

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -4,8 +4,9 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronLeft, AlertCircle, Volume2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { StageService } from '../services/StageService';
+import { WordRelationService } from '../services/WordRelationService';
 import LoadingSpinner from '../components/LoadingSpinner';
-import type { Word } from '../types';
+import type { Word, WordRelation } from '../types';
 
 export default function LearnPage() {
   const { stageId } = useParams<{ stageId: string }>();
@@ -16,6 +17,9 @@ export default function LearnPage() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [relations, setRelations] = useState<WordRelation[]>([]);
+  const [loadingRelations, setLoadingRelations] = useState(false);
+  const [speaking, setSpeaking] = useState(false);
 
   useEffect(() => {
     if (!stageId) return;
@@ -38,6 +42,62 @@ export default function LearnPage() {
     void load();
     return () => { cancelled = true; };
   }, [stageId]);
+
+  useEffect(() => {
+    const word = words[currentIndex];
+    if (!word) return;
+
+    setLoadingRelations(true);
+    WordRelationService.getRelations(word.wordId)
+      .then(setRelations)
+      .catch(() => setRelations([]))
+      .finally(() => setLoadingRelations(false));
+  }, [currentIndex, words]);
+
+  const speakWord = (word: string) => {
+    if (!window.speechSynthesis) {
+      toast.error('TTS를 지원하지 않는 브라우저입니다.');
+      return;
+    }
+
+    if (!word || word.trim() === '') {
+      toast.error('발음할 단어가 없습니다.');
+      return;
+    }
+
+    window.speechSynthesis.cancel();
+
+    const utterance = new SpeechSynthesisUtterance(word);
+    utterance.lang = 'en-US';
+    utterance.rate = 0.9;
+
+    utterance.onstart = () => setSpeaking(true);
+    utterance.onend = () => setSpeaking(false);
+    utterance.onerror = () => {
+      setSpeaking(false);
+      toast.error('발음 재생 중 오류가 발생했습니다.');
+    };
+
+    window.speechSynthesis.speak(utterance);
+  };
+
+  const getRelationBadgeClass = (type: string) => {
+    switch (type) {
+      case 'SYNONYM': return 'bg-blue-100 text-blue-700';
+      case 'ANTONYM': return 'bg-red-100 text-red-700';
+      case 'RELATED': return 'bg-green-100 text-green-700';
+      default: return 'bg-slate-100 text-slate-700';
+    }
+  };
+
+  const getRelationLabel = (type: string) => {
+    switch (type) {
+      case 'SYNONYM': return '유의어';
+      case 'ANTONYM': return '반의어';
+      case 'RELATED': return '관련어';
+      default: return type;
+    }
+  };
 
   if (loading) {
     return (
@@ -106,11 +166,16 @@ export default function LearnPage() {
 
             <div className="flex justify-center mb-4">
               <button
-                onClick={() => toast.info('Phase 2에서 제공됩니다')}
-                className="p-2 rounded-full hover:bg-slate-100 transition-colors text-slate-400"
-                aria-label="Pronounce word"
+                onClick={() => speakWord(word.word)}
+                disabled={speaking}
+                className={`p-3 rounded-full transition-all ${
+                  speaking
+                    ? 'bg-indigo-100 text-indigo-600 animate-pulse'
+                    : 'hover:bg-slate-100 text-slate-500 hover:text-indigo-600'
+                }`}
+                aria-label={`발음 듣기: ${word.word}`}
               >
-                <Volume2 className="w-5 h-5" />
+                <Volume2 className="w-6 h-6" />
               </button>
             </div>
 
@@ -124,9 +189,33 @@ export default function LearnPage() {
           </motion.div>
         </AnimatePresence>
 
-        {/* Related Words stub */}
-        <div className="bg-white rounded-2xl border border-slate-100 px-6 py-4 text-center text-slate-400 text-sm">
-          Related words (Phase 2)
+        {/* Related Words */}
+        <div className="bg-white rounded-2xl border border-slate-100 px-6 py-4">
+          <h3 className="text-sm font-bold text-slate-700 mb-3">관련 단어</h3>
+          {loadingRelations ? (
+            <div className="text-center py-4 text-slate-400 text-sm">
+              로딩 중...
+            </div>
+          ) : relations.length === 0 ? (
+            <div className="text-center py-4 text-slate-400 text-sm">
+              관련 단어가 없습니다
+            </div>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {relations.map((relation) => (
+                <div
+                  key={relation.id}
+                  className="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-50 border border-slate-100"
+                >
+                  <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${getRelationBadgeClass(relation.relationType)}`}>
+                    {getRelationLabel(relation.relationType)}
+                  </span>
+                  <span className="font-medium text-slate-800">{relation.relatedWord}</span>
+                  <span className="text-sm text-slate-500">{relation.relatedMeaning}</span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         {/* Navigation */}

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { CheckCircle, XCircle, ArrowLeft, ArrowRight, RotateCcw, Home, BookOpen, Trophy } from 'lucide-react';
+import { CheckCircle, XCircle, ArrowLeft, ArrowRight, RotateCcw, Home, BookOpen, Trophy, Clock, History } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { StageService } from '../services/StageService';
 import { ProgressService } from '../services/ProgressService';
@@ -9,11 +9,20 @@ import {
   subscribeProgressSyncStatus,
   type ProgressSyncStatus,
 } from '../services/OfflineProgressQueue';
-import { QuizSessionService } from '../services/QuizSessionService';
+import { QuizSessionService, type QuizSession, type QuizSessionDetail } from '../services/QuizSessionService';
 import LoadingSpinner from '../components/LoadingSpinner';
 import type { Stage, Word, QuizMode, IncorrectWord } from '../types';
 
-type QuizPhase = 'loading' | 'error' | 'incorrect-note' | 'mode-select' | 'quiz' | 'result';
+type QuizPhase =
+  | 'loading'
+  | 'error'
+  | 'incorrect-note'
+  | 'resume-select'
+  | 'mode-select'
+  | 'quiz'
+  | 'result'
+  | 'history-list'
+  | 'history-detail';
 
 interface QuestionResult {
   word: Word;
@@ -61,6 +70,11 @@ export default function QuizPage() {
     OfflineProgressQueue.hasPending() ? 'queued' : 'idle',
   );
 
+  // Resume & History states
+  const [draftSession, setDraftSession] = useState<QuizSession | null>(null);
+  const [completedSessions, setCompletedSessions] = useState<QuizSession[]>([]);
+  const [selectedSessionDetail, setSelectedSessionDetail] = useState<QuizSessionDetail | null>(null);
+
   const inputRef = useRef<HTMLInputElement>(null);
   const nextBtnRef = useRef<HTMLButtonElement>(null);
   const feedbackRef = useRef<HTMLDivElement>(null);
@@ -76,16 +90,26 @@ export default function QuizPage() {
 
     Promise.all([
       StageService.getStageById(sId),
-      ProgressService.getIncorrectWords()
+      ProgressService.getIncorrectWords(),
+      QuizSessionService.getDraftSessions(),
+      QuizSessionService.getCompletedSessions(sId),
     ])
-      .then(([s, allIw]) => {
+      .then(([s, allIw, drafts, completed]) => {
         setStage(s);
+        setCompletedSessions(completed);
         // Filter incorrect words for this stage
         const stageIw = allIw.filter(iw => s.words.some(w => w.wordId === iw.wordId));
         setIncorrectWords(stageIw);
 
+        const stageDraft = drafts.find(d => d.stageId === sId);
+        if (stageDraft) {
+          setDraftSession(stageDraft);
+        }
+
         if (stageIw.length > 0) {
           setPhase('incorrect-note');
+        } else if (stageDraft) {
+          setPhase('resume-select');
         } else {
           setPhase('mode-select');
         }
@@ -110,10 +134,8 @@ export default function QuizPage() {
     if (phase === 'quiz' && !submitted) {
       inputRef.current?.focus();
     } else if (phase === 'quiz' && submitted) {
-      // blur input first so mobile keyboard dismisses and full viewport is restored
       inputRef.current?.blur();
       feedbackRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-      // Delay focus so the Enter keydown event from the input doesn't leak into the button
       const id = setTimeout(() => nextBtnRef.current?.focus({ preventScroll: true }), 150);
       return () => clearTimeout(id);
     }
@@ -124,29 +146,123 @@ export default function QuizPage() {
   const getPrompt = (word: Word) => (mode === 'KtoE' ? word.meaning : word.word);
   const getCorrect = (word: Word) => (mode === 'KtoE' ? word.word : word.meaning);
 
-  const handleStartQuiz = (selectedMode: QuizMode) => {
+  const handleStartQuiz = async (selectedMode: QuizMode, resumeFrom?: { index: number; answers: QuestionResult[] }) => {
     setMode(selectedMode);
-    setCurrentIndex(0);
-    setResults([]);
+    if (resumeFrom) {
+      setCurrentIndex(resumeFrom.index);
+      setResults(resumeFrom.answers);
+    } else {
+      setCurrentIndex(0);
+      setResults([]);
+    }
     setAnswer('');
     setSubmitted(false);
     setPhase('quiz');
   };
 
-  const handleSubmit = () => {
+  const handleResumeDraft = async () => {
+    if (!draftSession || !stageId) return;
+    try {
+      const detail = await QuizSessionService.getSessionDetail(draftSession.id);
+      const resumeAnswers: QuestionResult[] = detail.answers.map(a => {
+        const existingWord = stage?.words.find(w => w.wordId === a.wordId);
+        return {
+          word: existingWord || {
+            wordId: a.wordId,
+            stageId: Number(stageId),
+            word: a.word,
+            meaning: a.meaning,
+            orderIndex: 0,
+            example: null,
+            imageUrl: null
+          },
+          userAnswer: a.userAnswer,
+          correctAnswer: a.correct ? a.word : a.meaning,
+          isCorrect: a.correct
+        };
+      });
+
+      await handleStartQuiz((draftSession.mode || 'KtoE') as QuizMode, {
+        index: draftSession.currentIndex || 0,
+        answers: resumeAnswers
+      });
+    } catch (err) {
+      console.error('Failed to load draft session:', err);
+      setDraftSession(null);
+      setPhase('mode-select');
+    }
+  };
+
+  const handleDeleteDraft = async () => {
+    if (!stageId) return;
+    try {
+      await QuizSessionService.deleteDraftSession(Number(stageId));
+      setDraftSession(null);
+      setPhase('mode-select');
+    } catch (err) {
+      console.error('Failed to delete draft session:', err);
+    }
+  };
+
+  const handleSubmit = async () => {
     const word = words[currentIndex];
     if (!word || submitted) return;
     const correctAnswer = getCorrect(word);
     const isCorrect = answer.trim().toLowerCase() === correctAnswer.trim().toLowerCase();
-    setResults((prev) => [...prev, { word, userAnswer: answer, correctAnswer, isCorrect }]);
+    const newResult = { word, userAnswer: answer, correctAnswer, isCorrect };
+
+    setResults((prev) => [...prev, newResult]);
     setSubmitted(true);
+
+    // Auto-save draft after each answer
+    if (stage && user) {
+      try {
+        await QuizSessionService.upsertDraftSession({
+          stageId: Number(stageId),
+          mode,
+          currentIndex: currentIndex + 1,
+          score: [...results, newResult].filter(r => r.isCorrect).length,
+          totalQuestions: words.length,
+          answers: [...results, newResult].map(r => ({
+            wordId: r.word.wordId,
+            userAnswer: r.userAnswer,
+            correct: r.isCorrect
+          }))
+        });
+      } catch (err) {
+        console.error('Failed to save draft:', err);
+      }
+    }
   };
 
-  const handleSkip = () => {
+  const handleSkip = async () => {
     const word = words[currentIndex];
     if (!word || submitted) return;
-    setResults((prev) => [...prev, { word, userAnswer: '', correctAnswer: getCorrect(word), isCorrect: false }]);
+    const correctAnswer = getCorrect(word);
+    const newResult = { word, userAnswer: '', correctAnswer, isCorrect: false };
+
+    setResults((prev) => [...prev, newResult]);
     setSubmitted(true);
+
+    // Auto-save draft after skip
+    if (stage && user) {
+      try {
+        await QuizSessionService.upsertDraftSession({
+          stageId: Number(stageId),
+          mode,
+          currentIndex: currentIndex + 1,
+          score: [...results, newResult].filter(r => r.isCorrect).length,
+          totalQuestions: words.length,
+          answers: [...results, newResult].map(r => ({
+            wordId: r.word.wordId,
+            userAnswer: r.userAnswer,
+            correct: r.isCorrect
+          }))
+        });
+      } catch (err) {
+        console.error('Failed to save draft:', err);
+      }
+    }
   };
 
   const handleNext = () => {
@@ -165,7 +281,6 @@ export default function QuizPage() {
     if (!user || !stageId) return;
     const sId = Number(stageId);
 
-    // [1] Update local state immediately with newly failed words (for Mock environments)
     const newlyFailed = finalResults.filter((r) => !r.isCorrect);
     if (newlyFailed.length > 0) {
       setIncorrectWords((prev) => {
@@ -173,7 +288,7 @@ export default function QuizPage() {
         newlyFailed.forEach((nf) => {
           if (!next.some((iw) => iw.wordId === nf.word.wordId)) {
             next.push({
-              incorrectWordId: Date.now() + Math.random(), // Temporary ID for mock
+              incorrectWordId: Date.now() + Math.random(),
               wordId: nf.word.wordId,
               uid: user.uid,
               count: 1,
@@ -185,14 +300,12 @@ export default function QuizPage() {
       });
     }
 
-    // [2] Identify words to resolve (was incorrect, now correct) - use current state before sync
     const correctIds = new Set(finalResults.filter((r) => r.isCorrect).map((r) => r.word.wordId));
     const toResolve =
       stage?.words.filter(
         (w) => correctIds.has(w.wordId) && incorrectWords.some((iw) => iw.wordId === w.wordId),
       ) ?? [];
 
-    // [3] Save and Sync (Async)
     try {
       await QuizSessionService.saveQuizResult({
         stageId: sId,
@@ -205,9 +318,12 @@ export default function QuizPage() {
         })),
       });
 
+      // Delete draft after successful submission
+      await QuizSessionService.deleteDraftSession(sId).catch(() => {});
+      setDraftSession(null);
+
       await ProgressService.markStageCompleted(sId);
 
-      // Re-fetch incorrect words to reflect new failures immediately from DB if possible
       const allIw = await ProgressService.getIncorrectWords();
       if (stage) {
         const stageIw = allIw.filter((iw) => stage.words.some((w) => w.wordId === iw.wordId));
@@ -218,12 +334,10 @@ export default function QuizPage() {
       try {
         await ProgressService.markStageCompleted(sId);
       } catch {
-        // ProgressService has already queued the completion when a retry is possible.
       }
       setSyncStatus(OfflineProgressQueue.hasPending() ? 'queued' : 'failed');
     }
 
-    // [4] Show Resolve Dialog if there are words to resolve
     if (toResolve.length > 0) {
       setWordsToResolve(toResolve);
       setShowResolveDialog(true);
@@ -235,11 +349,9 @@ export default function QuizPage() {
       await Promise.all(wordsToResolve.map((w) => ProgressService.resolveIncorrectWord(w.wordId)));
     } catch (err) {
       console.error('Failed to resolve words:', err);
-      // If in DEV mode, proceed to update local state anyway so the mock UI works
       if (!import.meta.env.DEV) return;
     }
 
-    // Sync local state after resolution (or mock resolution)
     setIncorrectWords((prev) =>
       prev.filter((iw) => !wordsToResolve.some((w) => w.wordId === iw.wordId)),
     );
@@ -253,6 +365,8 @@ export default function QuizPage() {
     setSubmitted(false);
     if (incorrectWords.length > 0) {
       setPhase('incorrect-note');
+    } else if (draftSession) {
+      setPhase('resume-select');
     } else {
       setPhase('mode-select');
     }
@@ -263,7 +377,40 @@ export default function QuizPage() {
     setResults([]);
     setAnswer('');
     setSubmitted(false);
-    setPhase('mode-select');
+    if (draftSession) {
+      setPhase('resume-select');
+    } else {
+      setPhase('mode-select');
+    }
+  };
+
+  const handleViewHistory = async () => {
+    setPhase('history-list');
+  };
+
+  const handleViewSessionDetail = async (sessionId: number) => {
+    try {
+      const detail = await QuizSessionService.getSessionDetail(sessionId);
+      setSelectedSessionDetail(detail);
+      setPhase('history-detail');
+    } catch (err) {
+      console.error('Failed to load session detail:', err);
+    }
+  };
+
+  const handleBackToHistoryList = () => {
+    setSelectedSessionDetail(null);
+    setPhase('history-list');
+  };
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleString('ko-KR', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
   };
 
   // ── Loading ───────────────────────────────────────────────
@@ -338,12 +485,110 @@ export default function QuizPage() {
 
           <button
             type="button"
-            onClick={() => setPhase('mode-select')}
+            onClick={() => draftSession ? setPhase('resume-select') : setPhase('mode-select')}
             className="w-full py-4 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-bold transition-all flex items-center justify-center gap-2"
           >
             모드 선택으로 계속하기
             <ArrowRight className="w-5 h-5" />
           </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Resume Select ────────────────────────────────────────
+
+  if (phase === 'resume-select' && stage) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl shadow-sm border border-slate-100 p-8 max-w-sm w-full">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            title="이전 페이지로 돌아갑니다"
+            aria-label="이전 페이지로 돌아가기"
+            className="flex items-center gap-1 text-slate-400 hover:text-slate-700 text-sm mb-4 -ml-1 transition-colors"
+          >
+            <ArrowLeft aria-hidden="true" className="w-4 h-4" />
+            이전
+          </button>
+
+          <div className="flex items-center gap-2 mb-6">
+            <span
+              aria-label={`난이도: ${DIFFICULTY_FULL[stage.difficulty]}`}
+              className={`text-xs font-semibold px-2.5 py-0.5 rounded-full ${DIFFICULTY_BADGE[stage.difficulty]}`}
+            >
+              {DIFFICULTY_LABEL[stage.difficulty]}
+            </span>
+            <span className="text-slate-500 text-sm">Stage {stage.stageNumber}</span>
+          </div>
+
+          <h2 className="text-xl font-bold text-slate-900 mb-2">이어서 풀기</h2>
+          <p className="text-slate-500 text-sm mb-6">
+            {draftSession ? `진행 중인 세션이 있습니다 (${draftSession.currentIndex}/${draftSession.totalQuestions}완료)` : '새로 시작하거나 이전 결과를 확인하세요.'}
+          </p>
+
+          <div className="flex flex-col gap-3 mb-6">
+            {draftSession && (
+              <button
+                type="button"
+                onClick={handleResumeDraft}
+                className="w-full py-4 px-5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-semibold transition-all flex items-center justify-center gap-2"
+              >
+                <Clock className="w-5 h-5" />
+                이어서 풀기
+              </button>
+            )}
+
+            <button
+              type="button"
+              onClick={() => handleStartQuiz('KtoE')}
+              className="w-full py-4 px-5 rounded-xl border-2 border-slate-200 hover:border-indigo-500 hover:bg-indigo-50 text-left transition-all group"
+            >
+              <span className="block font-semibold text-slate-900 group-hover:text-indigo-700">
+                새로 시작: 한 ➡️ EN
+              </span>
+              <span className="block text-sm text-slate-500 mt-0.5">
+                {draftSession ? '진행 중인 세션을 덮어쓰고 새로 시작합니다' : '새 퀴즈를 시작합니다'}
+              </span>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => handleStartQuiz('EtoK')}
+              className="w-full py-4 px-5 rounded-xl border-2 border-slate-200 hover:border-indigo-500 hover:bg-indigo-50 text-left transition-all group"
+            >
+              <span className="block font-semibold text-slate-900 group-hover:text-indigo-700">
+                새로 시작: EN ➡️ 한
+              </span>
+              <span className="block text-sm text-slate-500 mt-0.5">
+                {draftSession ? '진행 중인 세션을 덮어쓰고 새로 시작합니다' : '새 퀴즈를 시작합니다'}
+              </span>
+            </button>
+
+            {completedSessions.length > 0 && (
+              <button
+                type="button"
+                onClick={handleViewHistory}
+                className="w-full py-4 px-5 rounded-xl border-2 border-slate-200 hover:border-slate-400 hover:bg-slate-50 text-left transition-all group"
+              >
+                <span className="block font-semibold text-slate-700 group-hover:text-slate-900 flex items-center gap-2">
+                  <History className="w-4 h-4" />
+                  이전 결과 보기 ({completedSessions.length}개)
+                </span>
+              </button>
+            )}
+
+            {draftSession && (
+              <button
+                type="button"
+                onClick={handleDeleteDraft}
+                className="w-full py-2 text-sm text-red-500 hover:text-red-600 transition-colors"
+              >
+                진행 중인 세션 삭제
+              </button>
+            )}
+          </div>
         </div>
       </div>
     );
@@ -407,6 +652,137 @@ export default function QuizPage() {
                 영단어를 보고 한국어 뜻을 입력
               </span>
             </button>
+
+            {completedSessions.length > 0 && (
+              <button
+                type="button"
+                onClick={handleViewHistory}
+                className="w-full py-3 px-5 rounded-xl border border-slate-200 hover:border-slate-400 hover:bg-slate-50 text-left transition-all group mt-4"
+              >
+                <span className="block font-semibold text-slate-700 group-hover:text-slate-900 flex items-center gap-2">
+                  <History className="w-4 h-4" />
+                  이전 결과 보기 ({completedSessions.length}개)
+                </span>
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── History List ──────────────────────────────────────────
+
+  if (phase === 'history-list') {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl shadow-sm border border-slate-100 p-8 max-w-sm w-full">
+          <button
+            type="button"
+            onClick={() => draftSession ? setPhase('resume-select') : setPhase('mode-select')}
+            className="flex items-center gap-1 text-slate-400 hover:text-slate-700 text-sm mb-4 -ml-1 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            뒤로
+          </button>
+
+          <h2 className="text-xl font-bold text-slate-900 mb-6">이전 퀴즈 결과</h2>
+
+          {completedSessions.length === 0 ? (
+            <div className="text-center py-8 text-slate-400">
+              <History className="w-12 h-12 mx-auto mb-3 opacity-50" />
+              <p>완료된 퀴즈가 없습니다</p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3 max-h-96 overflow-y-auto">
+              {completedSessions.map((session) => (
+                <button
+                  key={session.id}
+                  onClick={() => handleViewSessionDetail(session.id)}
+                  className="w-full p-4 rounded-xl border border-slate-200 hover:border-indigo-500 hover:bg-indigo-50 text-left transition-all"
+                >
+                  <div className="flex justify-between items-center mb-1">
+                    <span className="font-bold text-slate-900">
+                      {session.score}/{session.totalQuestions} 정답
+                    </span>
+                    <span className={`text-xs font-semibold px-2 py-1 rounded-full ${
+                      session.score >= session.totalQuestions * 0.7 ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'
+                    }`}>
+                      {Math.round((session.score / session.totalQuestions) * 100)}%
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center text-sm text-slate-500">
+                    <span>{session.mode === 'KtoE' ? '한→영' : '영→한'}</span>
+                    <span>{formatDate(session.completedAt || session.startedAt)}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── History Detail ────────────────────────────────────────
+
+  if (phase === 'history-detail' && selectedSessionDetail) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl shadow-sm border border-slate-100 p-6 max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col">
+          <div className="flex items-center gap-2 mb-4">
+            <button
+              type="button"
+              onClick={handleBackToHistoryList}
+              className="flex items-center gap-1 text-slate-400 hover:text-slate-700 text-sm transition-colors"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              목록
+            </button>
+          </div>
+
+          <div className="text-center mb-4">
+            <div className="flex justify-center mb-2">
+              <div className="bg-amber-50 p-2 rounded-xl">
+                <Trophy className="w-5 h-5 text-amber-600" />
+              </div>
+            </div>
+            <h3 className="text-lg font-black text-slate-900 mb-1">
+              {selectedSessionDetail.score}/{selectedSessionDetail.totalQuestions}
+            </h3>
+            <p className="text-sm text-slate-500">
+              {selectedSessionDetail.mode === 'KtoE' ? '한→영' : '영→한'} · {formatDate(selectedSessionDetail.completedAt || selectedSessionDetail.startedAt)}
+            </p>
+          </div>
+
+          <div className="flex-1 overflow-y-auto">
+            <div className="flex flex-col gap-2">
+              {selectedSessionDetail.answers.map((answer, i) => (
+                <div
+                  key={i}
+                  className={`p-3 rounded-xl border ${
+                    answer.correct ? 'border-green-100 bg-green-50' : 'border-red-100 bg-red-50'
+                  }`}
+                >
+                  <div className="flex items-start gap-2">
+                    {answer.correct ? (
+                      <CheckCircle className="w-4 h-4 text-green-600 mt-0.5 shrink-0" />
+                    ) : (
+                      <XCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p className="font-semibold text-slate-900 truncate">{answer.word}</p>
+                      <p className="text-sm text-slate-600">{answer.meaning}</p>
+                      {!answer.correct && answer.userAnswer && (
+                        <p className="text-xs text-red-600 mt-1">
+                          내 답: {answer.userAnswer || '(공백)'}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </div>
@@ -448,7 +824,7 @@ export default function QuizPage() {
             </span>
           </div>
 
-          {/* Progress bar — NFR-01: 300ms transition well under 0.5s */}
+          {/* Progress bar */}
           <div
             role="progressbar"
             aria-valuenow={progressValue}
@@ -520,7 +896,7 @@ export default function QuizPage() {
             </div>
           )}
 
-          {/* Feedback (post-submit) — role="alert" announces to screen readers immediately */}
+          {/* Feedback (post-submit) */}
           {submitted && lastResult && (
             <div>
               <div

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -1,3 +1,238 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Trophy, TrendingUp, AlertCircle, ArrowLeft, Calendar } from 'lucide-react';
+import { RankingService } from '../services/RankingService';
+import LoadingSpinner from '../components/LoadingSpinner';
+import type { Ranking } from '../types';
+
+type Phase = 'loading' | 'error' | 'empty' | 'loaded';
+
 export default function RankingPage() {
-  return <div>RankingPage</div>;
+  const navigate = useNavigate();
+
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [rankings, setRankings] = useState<Ranking[]>([]);
+  const [period, setPeriod] = useState(() => {
+    const today = new Date();
+    return today.toISOString().split('T')[0];
+  });
+  const [errorMsg, setErrorMsg] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setPhase('loading');
+        const data = await RankingService.getRankings(period);
+        if (data.length === 0) {
+          setPhase('empty');
+        } else {
+          setRankings(data);
+          setPhase('loaded');
+        }
+      } catch (err) {
+        setPhase('error');
+        setErrorMsg('랭킹 데이터를 불러오지 못했습니다.');
+      }
+    };
+
+    void load();
+  }, [period]);
+
+  const getRankIcon = (rank: number) => {
+    switch (rank) {
+      case 1:
+        return (
+          <div className="w-8 h-8 rounded-full bg-yellow-400 flex items-center justify-center text-yellow-900 font-bold text-sm shadow-lg">
+            1
+          </div>
+        );
+      case 2:
+        return (
+          <div className="w-8 h-8 rounded-full bg-slate-300 flex items-center justify-center text-slate-700 font-bold text-sm shadow-lg">
+            2
+          </div>
+        );
+      case 3:
+        return (
+          <div className="w-8 h-8 rounded-full bg-amber-600 flex items-center justify-center text-amber-100 font-bold text-sm shadow-lg">
+            3
+          </div>
+        );
+      default:
+        return (
+          <div className="w-8 h-8 rounded-full bg-slate-100 flex items-center justify-center text-slate-500 font-bold text-sm">
+            {rank}
+          </div>
+        );
+    }
+  };
+
+  const getRankBadgeClass = (rank: number) => {
+    switch (rank) {
+      case 1: return 'bg-gradient-to-r from-yellow-400 to-amber-400 text-yellow-900 border-yellow-500';
+      case 2: return 'bg-gradient-to-r from-slate-200 to-slate-300 text-slate-700 border-slate-400';
+      case 3: return 'bg-gradient-to-r from-amber-500 to-amber-600 text-amber-100 border-amber-700';
+      default: return 'bg-white text-slate-700 border-slate-200';
+    }
+  };
+
+  // ── Loading ───────────────────────────────────────────────
+
+  if (phase === 'loading') {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center flex-col gap-4">
+        <LoadingSpinner />
+        <p className="text-slate-500">랭킹 데이터를 불러오는 중...</p>
+      </div>
+    );
+  }
+
+  // ── Error ─────────────────────────────────────────────────
+
+  if (phase === 'error') {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl shadow-sm border border-slate-100 p-8 max-w-sm w-full text-center">
+          <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
+          <p className="text-slate-900 font-semibold mb-2">오류가 발생했습니다</p>
+          <p className="text-slate-500 text-sm mb-6">{errorMsg}</p>
+          <button
+            onClick={() => navigate(-1)}
+            className="w-full py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-semibold transition-colors"
+          >
+            돌아가기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Empty ─────────────────────────────────────────────────
+
+  if (phase === 'empty') {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl shadow-sm border border-slate-100 p-8 max-w-sm w-full text-center">
+          <Trophy className="w-12 h-12 text-slate-300 mx-auto mb-4" />
+          <p className="text-slate-900 font-semibold mb-2">랭킹 데이터가 없습니다</p>
+          <p className="text-slate-500 text-sm mb-6">
+            아직 오답 데이터가 충분하지 않습니다.<br />
+            퀴즈를 더 풀어보세요!
+          </p>
+          <button
+            onClick={() => navigate('/select')}
+            className="w-full py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-semibold transition-colors"
+          >
+            스테이지 선택으로 가기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Loaded ────────────────────────────────────────────────
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* Header */}
+      <div className="bg-white border-b border-slate-100 sticky top-0 z-10">
+        <div className="max-w-lg mx-auto px-4 py-4 flex items-center justify-between">
+          <button
+            onClick={() => navigate(-1)}
+            className="flex items-center gap-1 text-slate-400 hover:text-slate-700 transition-colors"
+          >
+            <ArrowLeft className="w-5 h-5" />
+            <span className="text-sm">이전</span>
+          </button>
+
+          <div className="flex items-center gap-2">
+            <Trophy className="w-5 h-5 text-amber-500" />
+            <h1 className="text-lg font-bold text-slate-900">오답 TOP 10</h1>
+          </div>
+
+          <div className="w-12" />
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-lg mx-auto px-4 py-6">
+        {/* Period Selector */}
+        <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6 flex items-center justify-between">
+          <div className="flex items-center gap-2 text-slate-700">
+            <Calendar className="w-4 h-4" />
+            <span className="text-sm font-medium">기준일</span>
+          </div>
+          <input
+            type="date"
+            value={period}
+            onChange={(e) => setPeriod(e.target.value)}
+            max={new Date().toISOString().split('T')[0]}
+            className="px-3 py-1.5 rounded-lg border border-slate-200 text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+
+        {/* Info Box */}
+        <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4 mb-6">
+          <div className="flex items-start gap-3">
+            <TrendingUp className="w-5 h-5 text-indigo-600 mt-0.5 shrink-0" />
+            <div>
+              <p className="text-sm font-semibold text-indigo-900 mb-1">
+                가장 많이 틀린 단어 TOP 10
+              </p>
+              <p className="text-xs text-indigo-700">
+                선택한 날짜를 기준으로 누적 오답 횟수가 많은 순서대로 보여줍니다.
+                이 단어들을 집중적으로 연습하면 효율적으로 학습할 수 있어요!
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Ranking List */}
+        <div className="bg-white rounded-2xl shadow-sm border border-slate-100 overflow-hidden">
+          {rankings.map((item, index) => (
+            <div
+              key={item.id}
+              className={`flex items-center gap-4 p-4 ${
+                index !== rankings.length - 1 ? 'border-b border-slate-100' : ''
+              }`}
+            >
+              {/* Rank */}
+              <div className="shrink-0">
+                {getRankIcon(item.rank)}
+              </div>
+
+              {/* Word Info */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${getRankBadgeClass(item.rank)}`}>
+                    TOP {item.rank}
+                  </span>
+                  {index < 3 && (
+                    <span className="text-xs text-slate-400">
+                      {item.missCount}회 오답
+                    </span>
+                  )}
+                </div>
+                <p className="text-lg font-bold text-slate-900 truncate">{item.word}</p>
+                <p className="text-sm text-slate-600 truncate">{item.meaning}</p>
+              </div>
+
+              {/* Miss Count */}
+              <div className="shrink-0 text-right">
+                <p className="text-2xl font-black text-red-500">{item.missCount}</p>
+                <p className="text-xs text-slate-400">오답</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer Note */}
+        <div className="mt-6 text-center">
+          <p className="text-xs text-slate-400">
+            * 랭킹은 매일 자정에 업데이트됩니다
+          </p>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/services/QuizSessionService.ts
+++ b/frontend/src/services/QuizSessionService.ts
@@ -7,8 +7,62 @@ export interface SaveSessionRequest {
   answers: Array<{ wordId: number; userAnswer: string; correct: boolean }>;
 }
 
+export interface UpsertDraftSessionRequest {
+  stageId: number;
+  mode: 'KtoE' | 'EtoK';
+  currentIndex: number;
+  score: number;
+  totalQuestions: number;
+  answers: Array<{ wordId: number; userAnswer: string; correct: boolean }>;
+}
+
+export interface QuizSession {
+  id: number;
+  stageId: number;
+  mode: string | null;
+  currentIndex: number | null;
+  score: number;
+  totalQuestions: number;
+  startedAt: string;
+  completedAt: string | null;
+}
+
+export interface QuizSessionDetail extends QuizSession {
+  answers: Array<{
+    wordId: number;
+    word: string;
+    meaning: string;
+    userAnswer: string;
+    correct: boolean;
+  }>;
+}
+
 export class QuizSessionService {
   static async saveQuizResult(payload: SaveSessionRequest): Promise<void> {
     await http.post('/sessions', payload);
+  }
+
+  static async upsertDraftSession(payload: UpsertDraftSessionRequest): Promise<QuizSession> {
+    return http.put('/sessions/current', payload);
+  }
+
+  static async deleteDraftSession(stageId: number): Promise<void> {
+    await http.delete('/sessions/current', { params: { stageId } });
+  }
+
+  static async getSessions(stageId?: number, completed?: boolean): Promise<QuizSession[]> {
+    return http.get('/sessions', { params: { stageId, completed } });
+  }
+
+  static async getSessionDetail(id: number): Promise<QuizSessionDetail> {
+    return http.get(`/sessions/${id}`);
+  }
+
+  static async getDraftSessions(): Promise<QuizSession[]> {
+    return http.get('/sessions', { params: { completed: false } });
+  }
+
+  static async getCompletedSessions(stageId?: number): Promise<QuizSession[]> {
+    return http.get('/sessions', { params: { stageId, completed: true } });
   }
 }

--- a/frontend/src/services/RankingService.ts
+++ b/frontend/src/services/RankingService.ts
@@ -2,7 +2,7 @@ import http from '../lib/axios';
 import type { Ranking } from '../types';
 
 export class RankingService {
-  static async getRankings(): Promise<Ranking[]> {
-    return (await http.get('/rankings')) as unknown as Ranking[];
+  static async getRankings(period?: string): Promise<Ranking[]> {
+    return http.get('/rankings', { params: { period } });
   }
 }

--- a/frontend/src/services/WordRelationService.ts
+++ b/frontend/src/services/WordRelationService.ts
@@ -2,7 +2,7 @@ import http from '../lib/axios';
 import type { WordRelation } from '../types';
 
 export class WordRelationService {
-  static async getRelations(wordId: string): Promise<WordRelation[]> {
-    return (await http.get(`/word-relations/${wordId}`)) as unknown as WordRelation[];
+  static async getRelations(wordId: number): Promise<WordRelation[]> {
+    return http.get(`/word-relations/${wordId}`);
   }
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -103,15 +103,20 @@ export interface WordRelation {
   id: number;
   wordId: number;
   relatedWordId: number;
+  relatedWord: string;
+  relatedMeaning: string;
   relationType: string;
 }
 
 export interface Ranking {
   id: number;
-  uid: string;
-  score: number;
-  rankPosition: number;
+  wordId: number;
+  word: string;
+  meaning: string;
+  missCount: number;
+  rank: number;
   period: string;
+  snapshotDate: string;
 }
 
 export interface PvpRoom {


### PR DESCRIPTION
## Summary
- Add resumable quiz draft/session flow across backend and frontend.
- Update ranking and word relation surfaces used by the sanity flow.
- Add manual offline/draft test scenarios.
- Fix the browser-found backend 500 by marking the quiz-answer JPQL delete as a modifying query.
- Fix Excel upload service tests to use real in-memory workbook bytes instead of empty byte arrays.

## Browser Sanity
- Opened the app locally with dev auth enabled.
- Navigated home -> stage select -> learn stage 1 -> quiz.
- Submitted a quiz answer, verified draft persistence through the sessions API, and verified the resume UI appeared.
- Deleted the draft test session afterward.

## Validation
- `.\gradlew.bat :backend:test`
- `.\node_modules\.bin\tsc.cmd -b`
- `.\node_modules\.bin\vite.cmd build`
- `git diff --check`

## Notes
- Vite build still reports the existing large chunk warning, but the production build completes successfully.