### PR TITLE
fix: Node.js 24 강제 실행으로 인한 app.jar 손상 및 배포 실패 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,7 +184,7 @@ jobs:
           script: |
             test -s /opt/tokki/backend/app.jar
             ls -lh /opt/tokki/backend/app.jar
-            unzip -t /opt/tokki/backend/app.jar > /dev/null \
+            jar tf /opt/tokki/backend/app.jar > /dev/null \
               && echo "✅ JAR 유효" \
               || { echo "❌ JAR 파일이 손상되었습니다"; exit 1; }
 
@@ -256,6 +256,18 @@ jobs:
               pm2 logs tokki-backend --lines 120 --nostream || true
               exit 1
             fi
+
+      - name: Restore backend on failure
+        if: failure()
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            echo "=== 배포 실패 — 백엔드 복구 시도 ==="
+            pm2 restart tokki-backend || pm2 start java --name tokki-backend --time -- -jar /opt/tokki/backend/app.jar
+            pm2 status
 
       - name: Reload Nginx
         uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,9 +11,6 @@ concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -157,6 +154,16 @@ jobs:
       # ==========================================
       # 4. 서버로 파일 전송 (SCP)
       # ==========================================
+      - name: Stop backend before transfer
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            pm2 stop tokki-backend || true
+            mkdir -p /opt/tokki/backend/logs
+
       - name: Transfer backend JAR to server
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -175,10 +182,11 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.SSH_KEY }}
           script: |
-            # 로그 디렉토리 확인
-            mkdir -p /opt/tokki/backend/logs
             test -s /opt/tokki/backend/app.jar
             ls -lh /opt/tokki/backend/app.jar
+            unzip -t /opt/tokki/backend/app.jar > /dev/null \
+              && echo "✅ JAR 유효" \
+              || { echo "❌ JAR 파일이 손상되었습니다"; exit 1; }
 
       - name: Transfer frontend dist to server
         uses: appleboy/scp-action@v0.1.7


### PR DESCRIPTION
## 문제 원인

Actions run [#26145335235](https://github.com/26-smu-softeng-06t/TOKKI/actions/runs/26145335235) 에서 배포가 실패하며 서버에서 다음 오류 발생:

```
Error: Invalid or corrupt jarfile app.jar
```

### 손상 경로

1. 워크플로우에 설정된 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` 환경변수가 **모든 스텝과 Docker 컨테이너에 전파**됨
2. `appleboy/scp-action@v0.1.7` (Docker 액션)의 Action Runner가 Node.js 24로 강제 실행되면서 **125MB 대용량 JAR 전송이 중간에 중단**되지만 에러는 반환하지 않음
3. 서버에 전달된 app.jar는 ZIP End of Central Directory 레코드가 누락된 **절반짜리 파일**
4. 기존 검증(`test -s`)은 "비어있지 않음"만 확인하므로 손상을 감지하지 못하고 통과
5. pm2가 `java -jar app.jar` 실행 시 `Invalid or corrupt jarfile` 발생, 769회 이상 크래시 루프

```
Runner: 125MB 정상 JAR
    ↓ FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 → Node.js 24 강제 실행
    ↓ appleboy/scp-action (전송 중단, 에러 없음)
Server: 절반만 전송된 app.jar (test -s 통과, unzip 불가)
    ↓ pm2 restart
    ↓ java -jar app.jar
❌ Error: Invalid or corrupt jarfile
```

## 변경 사항

### 1. `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` 제거 (근본 원인)
Node.js 20→24 강제 실행을 opt-in하는 환경변수 제거. 각 action이 설계된 런타임으로 동작하도록 복원.

### 2. SCP 전송 전 pm2 정지 단계 추가
pm2 크래시 루프가 진행 중인 상태에서 SCP가 파일을 덮어쓸 때 발생하는 Race Condition 방지.

```yaml
- name: Stop backend before transfer
  script: |
    pm2 stop tokki-backend || true
```

### 3. JAR 유효성 검증 강화
`test -s`(비어있지 않음 확인) 단독에서 `unzip -t`로 ZIP 포맷 자체를 검증하도록 개선. 손상된 JAR가 전송될 경우 이 단계에서 배포를 즉시 중단.

```yaml
unzip -t /opt/tokki/backend/app.jar > /dev/null \
  && echo "✅ JAR 유효" \
  || { echo "❌ JAR 파일이 손상되었습니다"; exit 1; }
```

## 테스트 계획

- [x] `dev` 브랜치 push 후 Actions 워크플로우 정상 완료 확인 ([run #26146424406](https://github.com/26-smu-softeng-06t/TOKKI/actions/runs/26146424406) ✅)
- [x] 서버 포트 4000에서 백엔드 응답 확인 (`/api/auth/me` → 200/401)
- [x] pm2 재시작 횟수가 증가하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)