### PR TITLE
perf(backend): GET /stages N+1 쿼리 제거

### DIFF
--- a/backend/src/main/java/com/tokki/repository/WordRepository.java
+++ b/backend/src/main/java/com/tokki/repository/WordRepository.java
@@ -4,11 +4,15 @@ import com.tokki.domain.Word;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface WordRepository extends JpaRepository<Word, Long> {
     List<Word> findByStageIdOrderByOrderIndexAscIdAsc(Long stageId);
+
+    @Query("SELECT w FROM Word w WHERE w.stage.id IN :stageIds ORDER BY w.orderIndex ASC, w.id ASC")
+    List<Word> findByStageIdInOrderByOrderIndexAscIdAsc(@Param("stageIds") List<Long> stageIds);
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Word w WHERE w.stage.id = :stageId")

--- a/backend/src/main/java/com/tokki/service/StageService.java
+++ b/backend/src/main/java/com/tokki/service/StageService.java
@@ -18,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,10 +30,7 @@ public class StageService {
 
     @Transactional(readOnly = true)
     public List<StageResponse> getAllStages() {
-        return stageRepository.findAll().stream()
-                .sorted(stageComparator())
-                .map(StageResponse::from)
-                .toList();
+        return toResponsesWithWords(stageRepository.findAll());
     }
 
     @Transactional(readOnly = true)
@@ -45,17 +44,26 @@ public class StageService {
         if (difficulty == null) {
             throw new AppException(ErrorCode.INVALID_INPUT);
         }
-        if (stageNumber == null) {
-            return stageRepository.findByDifficulty(difficulty).stream()
-                    .sorted(stageComparator())
-                    .map(StageResponse::from)
-                    .toList();
-        }
-        return stageRepository.findByDifficultyAndStageNumber(difficulty, stageNumber)
-                .map(List::of)
-                .orElse(List.of())
+        List<Stage> stages = stageNumber == null
+                ? stageRepository.findByDifficulty(difficulty)
+                : stageRepository.findByDifficultyAndStageNumber(difficulty, stageNumber)
+                        .map(List::of).orElse(List.of());
+        return toResponsesWithWords(stages);
+    }
+
+    private List<StageResponse> toResponsesWithWords(List<Stage> stages) {
+        if (stages.isEmpty()) return List.of();
+        List<Long> ids = stages.stream().map(Stage::getId).toList();
+        Map<Long, List<WordResponse>> wordsByStage = wordRepository
+                .findByStageIdInOrderByOrderIndexAscIdAsc(ids)
                 .stream()
-                .map(StageResponse::from)
+                .collect(Collectors.groupingBy(
+                        w -> w.getStage().getId(),
+                        Collectors.mapping(WordResponse::from, Collectors.toList())
+                ));
+        return stages.stream()
+                .sorted(stageComparator())
+                .map(s -> StageResponse.from(s, wordsByStage.getOrDefault(s.getId(), List.of())))
                 .toList();
     }
 

--- a/backend/src/test/java/com/tokki/service/StageServiceTest.java
+++ b/backend/src/test/java/com/tokki/service/StageServiceTest.java
@@ -2,6 +2,7 @@ package com.tokki.service;
 
 import com.tokki.domain.DifficultyLevel;
 import com.tokki.domain.Stage;
+import com.tokki.domain.Word;
 import com.tokki.dto.request.BatchStageRequest;
 import com.tokki.dto.request.CreateStageRequest;
 import com.tokki.dto.request.StageWordRequest;
@@ -69,6 +70,42 @@ class StageServiceTest {
         assertThatThrownBy(() -> stageService.getStages("low", 11))
                 .isInstanceOf(AppException.class)
                 .hasMessageContaining("잘못된 입력값");
+    }
+
+    @Test
+    void toResponsesWithWordsGroupsAndOrdersWordsByStage() {
+        Stage stageA = Stage.builder()
+                .id(1L).difficulty(DifficultyLevel.easy).stageNumber(1)
+                .level(1).title("Easy Stage 1").description("Easy level - Stage 1")
+                .build();
+        Stage stageB = Stage.builder()
+                .id(2L).difficulty(DifficultyLevel.medium).stageNumber(1)
+                .level(1).title("Medium Stage 1").description("Medium level - Stage 1")
+                .build();
+
+        // DB 글로벌 정렬(orderIndex ASC) 결과를 시뮬레이션 — 두 스테이지의 단어가 섞여서 반환됨
+        Word wordA1 = Word.builder().id(1L).stage(stageA).word("apple").meaning("사과").orderIndex(1).build();
+        Word wordB1 = Word.builder().id(2L).stage(stageB).word("cat").meaning("고양이").orderIndex(1).build();
+        Word wordA2 = Word.builder().id(3L).stage(stageA).word("banana").meaning("바나나").orderIndex(2).build();
+        Word wordB2 = Word.builder().id(4L).stage(stageB).word("dog").meaning("강아지").orderIndex(2).build();
+
+        when(stageRepository.findAll()).thenReturn(List.of(stageA, stageB));
+        when(wordRepository.findByStageIdInOrderByOrderIndexAscIdAsc(List.of(1L, 2L)))
+                .thenReturn(List.of(wordA1, wordB1, wordA2, wordB2));
+
+        List<StageResponse> result = stageService.getAllStages();
+
+        assertThat(result).hasSize(2);
+        StageResponse responseA = result.stream().filter(r -> r.getStageId().equals(1L)).findFirst().orElseThrow();
+        StageResponse responseB = result.stream().filter(r -> r.getStageId().equals(2L)).findFirst().orElseThrow();
+
+        assertThat(responseA.getWords()).hasSize(2);
+        assertThat(responseA.getWords().get(0).getWord()).isEqualTo("apple");
+        assertThat(responseA.getWords().get(1).getWord()).isEqualTo("banana");
+
+        assertThat(responseB.getWords()).hasSize(2);
+        assertThat(responseB.getWords().get(0).getWord()).isEqualTo("cat");
+        assertThat(responseB.getWords().get(1).getWord()).isEqualTo("dog");
     }
 
     @Test


### PR DESCRIPTION
## 문제

`GET /stages` 호출 시 스테이지 수(N)만큼 `SELECT words WHERE stage_id = ?` 쿼리가 추가 발생하는 N+1 문제.
스테이지 30개 기준 DB 쿼리 31회 → Admin Panel 및 SelectPage 로딩에 수십 초 소요.

## 원인

`StageService.getAllStages()` / `getStages()`에서 각 스테이지를 `StageResponse::from(stage)`으로 변환 시 `words: List.of()`(빈 배열)를 반환하고, 프론트엔드가 별도로 `/stages/{id}/words`를 N번 호출하는 구조.

## 변경 내용

- `WordRepository` — `findByStageIdInOrderByOrderIndexAscIdAsc(List<Long>)` 추가 (JPQL IN 쿼리)
- `StageService` — `toResponsesWithWords(List<Stage>)` 헬퍼 추가
  - 스테이지 ID 목록으로 단어를 **1회 배치 조회** 후 stageId 기준으로 그룹핑
  - `getAllStages()` / `getStages()` 모두 헬퍼를 통해 words 포함 응답 반환

## 결과

| | 변경 전 | 변경 후 |
|---|---|---|
| DB 쿼리 수 (스테이지 30개 기준) | 31회 | **2회** |

## 테스트

- `./gradlew :backend:test` — 전체 통과