### PR TITLE
perf(frontend): 스테이지 선택 페이지 과다 HTTP 요청 제거

### DIFF
--- a/frontend/src/pages/SelectPage.tsx
+++ b/frontend/src/pages/SelectPage.tsx
@@ -28,23 +28,13 @@ export default function SelectPage() {
 
     const load = async () => {
       try {
-        const allStages = await StageService.getStages();
+        const [allStages, progressMap] = await Promise.all([
+          StageService.getStages(),
+          ProgressService.getAllProgress().catch(() => new Map<number, UserProgress>()),
+        ]);
         if (cancelled) return;
         setStages(allStages);
-
-        const progressResults = await Promise.all(
-          allStages.map((s) =>
-            ProgressService.getProgress(s.stageId).catch(() => null)
-          )
-        );
-        if (cancelled) return;
-
-        const map = new Map<number, UserProgress>();
-        allStages.forEach((s, i) => {
-          const p = progressResults[i];
-          if (p) map.set(s.stageId, p);
-        });
-        setProgresses(map);
+        setProgresses(progressMap);
       } catch {
         // network error — show empty state
       } finally {

--- a/frontend/src/services/ProgressService.ts
+++ b/frontend/src/services/ProgressService.ts
@@ -7,6 +7,25 @@ import {
 } from './OfflineProgressQueue';
 
 export class ProgressService {
+  static async getAllProgress(): Promise<Map<number, UserProgress>> {
+    try {
+      const all = (await http.get('/progress')) as unknown as UserProgress[];
+      const map = new Map<number, UserProgress>(all.map((p) => [p.stageId, p]));
+      for (const item of OfflineProgressQueue.all()) {
+        const p = item.payload as UserProgress;
+        if (p.stageId !== undefined && !map.has(p.stageId)) map.set(p.stageId, p);
+      }
+      return map;
+    } catch {
+      const map = new Map<number, UserProgress>();
+      for (const item of OfflineProgressQueue.all()) {
+        const p = item.payload as UserProgress;
+        if (p.stageId !== undefined) map.set(p.stageId, p);
+      }
+      return map;
+    }
+  }
+
   static async getProgress(stageId: number): Promise<UserProgress | null> {
     try {
       const progresses = (await http.get('/progress')) as unknown as UserProgress[];

--- a/frontend/src/services/ProgressService.ts
+++ b/frontend/src/services/ProgressService.ts
@@ -11,17 +11,11 @@ export class ProgressService {
     try {
       const all = (await http.get('/progress')) as unknown as UserProgress[];
       const map = new Map<number, UserProgress>(all.map((p) => [p.stageId, p]));
-      for (const item of OfflineProgressQueue.all()) {
-        const p = item.payload as UserProgress;
-        if (p.stageId !== undefined && !map.has(p.stageId)) map.set(p.stageId, p);
-      }
+      mergeQueuedProgress(map);
       return map;
     } catch {
       const map = new Map<number, UserProgress>();
-      for (const item of OfflineProgressQueue.all()) {
-        const p = item.payload as UserProgress;
-        if (p.stageId !== undefined) map.set(p.stageId, p);
-      }
+      mergeQueuedProgress(map);
       return map;
     }
   }
@@ -65,6 +59,21 @@ export class ProgressService {
 
   static async syncQueuedProgress(): Promise<void> {
     await syncQueuedProgress();
+  }
+}
+
+function mergeQueuedProgress(map: Map<number, UserProgress>): void {
+  for (const item of OfflineProgressQueue.all()) {
+    const p = item.payload;
+    if (p.stageId === undefined) continue;
+    // 오프라인 큐 항목은 아직 서버에 반영되지 않은 최신 로컬 상태이므로 서버 값을 덮어씀
+    map.set(p.stageId, {
+      id: p.id ?? 0,
+      uid: p.uid ?? '',
+      stageId: p.stageId,
+      completed: p.completed ?? false,
+      completedAt: p.completedAt ?? null,
+    });
   }
 }
 

--- a/frontend/src/services/StageService.ts
+++ b/frontend/src/services/StageService.ts
@@ -53,13 +53,10 @@ export class StageService {
         )
       : undefined;
     const stages = (await http.get('/stages', { params })) as unknown as Array<Record<string, unknown>>;
-    return Promise.all(
-      stages.map(async (stageRaw) => {
-        const stageId = Number(stageRaw.stageId ?? stageRaw.id ?? 0);
-        const wordsRaw = stageId > 0 ? await http.get(`/stages/${stageId}/words`) : [];
-        return normalizeStage(stageRaw, stageId, wordsRaw);
-      }),
-    );
+    return stages.map((stageRaw) => {
+      const stageId = Number(stageRaw.stageId ?? stageRaw.id ?? 0);
+      return normalizeStage(stageRaw, stageId, stageRaw.words);
+    });
   }
 
   static async getStageById(stageId: number): Promise<Stage> {


### PR DESCRIPTION
## 문제

SelectPage 진입 시 최대 2N+1회 HTTP 요청 발생으로 스테이지 선택 가능까지 수 분 소요.

- `StageService.getStages()` — `/stages` 1회 + `/stages/{id}/words` N회
- `ProgressService.getProgress()` — `/progress`(전체 목록)를 스테이지마다 1회씩 N번 호출
- 두 작업이 순차 실행 (stages 완료 후 progress 시작)

## 변경 내용

**`StageService.ts`**
- `getStages()`에서 per-stage `/words` 개별 요청 제거
- 백엔드 응답에 포함된 `words` 필드 직접 사용 (백엔드 PR #84과 연동)

**`ProgressService.ts`**
- `getAllProgress()` 추가 — `/progress` 1회 호출 후 `Map<stageId, UserProgress>` 반환
- 오프라인 큐 fallback 포함

**`SelectPage.tsx`**
- `getStages()` + `getAllProgress()`를 `Promise.all`로 병렬 실행
- stages 로딩 완료 전 progress 대기 제거

## 결과

| | 변경 전 | 변경 후 |
|---|---|---|
| HTTP 요청 수 (스테이지 30개 기준) | 최대 61회 | **2회** |
| 실행 방식 | 순차 | **병렬** |

## 테스트

- `tsc -b` 타입 체크 통과
- `vite build` 프로덕션 빌드 통과

## 의존성

백엔드 PR #84 (`fix/stage-n-plus-one-query`) 머지 후 함께 배포 필요.