### PR TITLE
fix: admin 로그인 후 /login으로 튕기는 버그 수정

### DIFF
--- a/frontend/src/pages/LoginCallbackPage.tsx
+++ b/frontend/src/pages/LoginCallbackPage.tsx
@@ -68,10 +68,10 @@ export default function LoginCallbackPage() {
         <p className="text-slate-500 mt-2 mb-6">{user.email}</p>
 
         <button
-          onClick={() => navigate(user.role === 'admin' ? '/admin' : '/', { replace: true })}
+          onClick={() => navigate('/', { replace: true })}
           className="bg-indigo-600 hover:bg-indigo-700 text-white w-full rounded-lg py-3 font-medium transition-colors"
         >
-          {user.role === 'admin' ? 'Admin Panel로 이동' : '시작하기'}
+          시작하기
         </button>
 
         {user.role !== 'admin' && (

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -21,7 +21,7 @@ export default function LoginPage() {
   const handleGoogleSignIn = async () => {
     setSigningIn(true);
     try {
-      const signedInUser = await AuthService.startGoogleSignIn();
+      await AuthService.startGoogleSignIn();
       navigate('/login/callback', { replace: true });
     } catch (err) {
       toast.error(err instanceof Error ? err.message : '로그인에 실패했습니다');

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -22,7 +22,7 @@ export default function LoginPage() {
     setSigningIn(true);
     try {
       const signedInUser = await AuthService.startGoogleSignIn();
-      navigate(signedInUser.role === 'admin' ? '/admin' : '/login/callback', { replace: true });
+      navigate('/login/callback', { replace: true });
     } catch (err) {
       toast.error(err instanceof Error ? err.message : '로그인에 실패했습니다');
       setSigningIn(false);


### PR DESCRIPTION
## 문제

admin 권한을 가진 유저가 Google 로그인 성공 후 `/login`으로 다시 튕기는 버그.

### 원인

로그인 성공 시 `LoginPage`에서 role에 따라 분기했는데, admin 유저는 `/login/callback`을 거치지 않고 `/admin`으로 직행했다. `/login/callback`이 바로 `AuthService.issueToken()`을 호출해 `AuthContext.user`를 세팅하는 유일한 경로였기 때문에, admin 유저는 `AuthContext.user`가 `null`인 채로 `/admin`에 도달하고, `AdminRoute`의 `if (!user) return <Navigate to="/login" />` 조건에 걸려 `/login`으로 리다이렉트됐다.

```
// 기존 흐름 (admin)
/login → startGoogleSignIn() → navigate('/admin')
→ AdminRoute: user=null → <Navigate to="/login" />  ← 버그
```

```
// 기존 흐름 (일반 유저)
/login → startGoogleSignIn() → navigate('/login/callback')
→ issueToken() → setAuthenticatedUser() → AuthContext.user 세팅
→ 버튼 클릭 → / → PrivateRoute 통과 ✓
```

### 해결

`MainPage`에 이미 admin에게만 보이는 Admin Panel 버튼이 존재하므로, 로그인 후 `/admin`으로 자동 리다이렉트할 필요가 없다. role 분기를 제거하고 모든 유저를 `/login/callback`으로 통일하면, `AuthContext.user`가 항상 정상 세팅된 뒤 `/`로 이동하게 된다.

```
// 수정 후 (admin 포함 모든 유저)
/login → startGoogleSignIn() → navigate('/login/callback')
→ issueToken() → setAuthenticatedUser() → AuthContext.user 세팅
→ 시작하기 클릭 → / → MainPage (admin에게 Admin Panel 버튼 노출)
```

## 변경 사항

- **`LoginPage.tsx`**: 로그인 성공 시 role 분기 제거, 모두 `/login/callback`으로 이동
- **`LoginCallbackPage.tsx`**: 버튼 목적지를 항상 `/`로 통일, 라벨 "시작하기"로 고정

## 테스트 체크리스트

- [x] 일반 유저 Google 로그인 → `/login/callback` → 시작하기 → `/` (MainPage) 정상 이동
- [x] admin 유저 Google 로그인 → `/login/callback` → 시작하기 → `/` → Admin Panel 버튼 확인
- [x] admin 유저 Admin Panel 버튼 클릭 → `/admin` 정상 진입
- [x] 일반 유저가 `/login/callback`에서 관리자 코드 입력 → admin 승격 후 `/admin` 이동
- [x] 미로그인 상태에서 `/` 직접 접근 → `/login` 리다이렉트 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)