### PR TITLE
fix: Admin 단어 수정 시 FK 제약 위반으로 발생하던 500 에러 수정

### DIFF
--- a/backend/src/main/java/com/tokki/service/StageService.java
+++ b/backend/src/main/java/com/tokki/service/StageService.java
@@ -131,23 +131,44 @@ public class StageService {
         return StageResponse.from(stage, getWordsByStage(stage.getId()));
     }
 
-    private void replaceWords(Stage stage, List<StageWordRequest> words) {
-        wordRepository.deleteByStageId(stage.getId());
-        if (words == null || words.isEmpty()) {
+    private void replaceWords(Stage stage, List<StageWordRequest> newWords) {
+        if (newWords == null || newWords.isEmpty()) {
             return;
         }
-        List<Word> newWords = words.stream()
+        List<Word> existing = wordRepository.findByStageIdOrderByOrderIndexAscIdAsc(stage.getId());
+        Map<Integer, Word> existingByOrder = existing.stream()
+                .collect(Collectors.toMap(Word::getOrderIndex, w -> w));
+        var incomingIndexes = newWords.stream()
+                .map(StageWordRequest::getOrderIndex)
+                .collect(Collectors.toSet());
+
+        List<Word> toSave = newWords.stream()
                 .sorted(Comparator.comparing(StageWordRequest::getOrderIndex))
-                .map(word -> Word.builder()
-                        .stage(stage)
-                        .word(word.getWord())
-                        .meaning(word.getMeaning())
-                        .example(word.getExample())
-                        .imageUrl(word.getImageUrl())
-                        .orderIndex(word.getOrderIndex())
-                        .build())
+                .map(req -> {
+                    Word ex = existingByOrder.get(req.getOrderIndex());
+                    if (ex != null) {
+                        ex.update(req.getWord(), req.getMeaning(), req.getExample(), req.getImageUrl(), req.getOrderIndex());
+                        return ex;
+                    }
+                    return Word.builder()
+                            .stage(stage)
+                            .word(req.getWord())
+                            .meaning(req.getMeaning())
+                            .example(req.getExample())
+                            .imageUrl(req.getImageUrl())
+                            .orderIndex(req.getOrderIndex())
+                            .build();
+                })
                 .toList();
-        wordRepository.saveAll(newWords);
+
+        List<Word> toDelete = existing.stream()
+                .filter(w -> !incomingIndexes.contains(w.getOrderIndex()))
+                .toList();
+        if (!toDelete.isEmpty()) {
+            wordRepository.deleteAll(toDelete);
+        }
+
+        wordRepository.saveAll(toSave);
     }
 
     private Stage getStageEntity(Long stageId) {

--- a/backend/src/main/java/com/tokki/service/StageService.java
+++ b/backend/src/main/java/com/tokki/service/StageService.java
@@ -137,7 +137,7 @@ public class StageService {
         }
         List<Word> existing = wordRepository.findByStageIdOrderByOrderIndexAscIdAsc(stage.getId());
         Map<Integer, Word> existingByOrder = existing.stream()
-                .collect(Collectors.toMap(Word::getOrderIndex, w -> w));
+                .collect(Collectors.toMap(Word::getOrderIndex, w -> w, (a, b) -> b));
         var incomingIndexes = newWords.stream()
                 .map(StageWordRequest::getOrderIndex)
                 .collect(Collectors.toSet());

--- a/backend/src/test/java/com/tokki/service/StageServiceTest.java
+++ b/backend/src/test/java/com/tokki/service/StageServiceTest.java
@@ -17,8 +17,12 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
 
 class StageServiceTest {
 
@@ -106,6 +110,117 @@ class StageServiceTest {
         assertThat(responseB.getWords()).hasSize(2);
         assertThat(responseB.getWords().get(0).getWord()).isEqualTo("cat");
         assertThat(responseB.getWords().get(1).getWord()).isEqualTo("dog");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void replaceWords_updatesExistingWordInPlaceAndPreservesId() {
+        Stage stage = Stage.builder()
+                .id(1L).difficulty(DifficultyLevel.easy).stageNumber(1)
+                .level(1).title("Easy Stage 1").description("Easy level - Stage 1")
+                .build();
+        Word existingWord = Word.builder()
+                .id(10L).stage(stage).word("apple").meaning("사과").orderIndex(1)
+                .build();
+
+        when(stageRepository.findById(1L)).thenReturn(Optional.of(stage));
+        when(stageRepository.existsById(1L)).thenReturn(true);
+        when(wordRepository.findByStageIdOrderByOrderIndexAscIdAsc(1L))
+                .thenReturn(List.of(existingWord));
+
+        CreateStageRequest request = new CreateStageRequest();
+        request.setDifficulty(DifficultyLevel.easy);
+        request.setStageNumber(1);
+        StageWordRequest wordReq = new StageWordRequest();
+        wordReq.setWord("orange");
+        wordReq.setMeaning("오렌지");
+        wordReq.setOrderIndex(1);
+        request.setWords(List.of(wordReq));
+
+        stageService.updateStage(1L, request);
+
+        ArgumentCaptor<List<Word>> captor = ArgumentCaptor.forClass(List.class);
+        verify(wordRepository).saveAll(captor.capture());
+        List<Word> saved = captor.getValue();
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).getId()).isEqualTo(10L);
+        assertThat(saved.get(0).getWord()).isEqualTo("orange");
+        verify(wordRepository, never()).deleteAll(any(List.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void replaceWords_insertsNewWordForNewOrderIndex() {
+        Stage stage = Stage.builder()
+                .id(1L).difficulty(DifficultyLevel.easy).stageNumber(1)
+                .level(1).title("Easy Stage 1").description("Easy level - Stage 1")
+                .build();
+        Word existingWord = Word.builder()
+                .id(10L).stage(stage).word("apple").meaning("사과").orderIndex(1)
+                .build();
+
+        when(stageRepository.findById(1L)).thenReturn(Optional.of(stage));
+        when(stageRepository.existsById(1L)).thenReturn(true);
+        when(wordRepository.findByStageIdOrderByOrderIndexAscIdAsc(1L))
+                .thenReturn(List.of(existingWord));
+
+        CreateStageRequest request = new CreateStageRequest();
+        request.setDifficulty(DifficultyLevel.easy);
+        request.setStageNumber(1);
+        StageWordRequest keepReq = new StageWordRequest();
+        keepReq.setWord("apple");
+        keepReq.setMeaning("사과");
+        keepReq.setOrderIndex(1);
+        StageWordRequest newReq = new StageWordRequest();
+        newReq.setWord("banana");
+        newReq.setMeaning("바나나");
+        newReq.setOrderIndex(2);
+        request.setWords(List.of(keepReq, newReq));
+
+        stageService.updateStage(1L, request);
+
+        ArgumentCaptor<List<Word>> captor = ArgumentCaptor.forClass(List.class);
+        verify(wordRepository).saveAll(captor.capture());
+        List<Word> saved = captor.getValue();
+        assertThat(saved).hasSize(2);
+        assertThat(saved.stream().anyMatch(w -> Long.valueOf(10L).equals(w.getId()))).isTrue();
+        assertThat(saved.stream().anyMatch(w -> w.getId() == null && "banana".equals(w.getWord()))).isTrue();
+        verify(wordRepository, never()).deleteAll(any(List.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void replaceWords_deletesWordRemovedFromIncomingList() {
+        Stage stage = Stage.builder()
+                .id(1L).difficulty(DifficultyLevel.easy).stageNumber(1)
+                .level(1).title("Easy Stage 1").description("Easy level - Stage 1")
+                .build();
+        Word word1 = Word.builder()
+                .id(10L).stage(stage).word("apple").meaning("사과").orderIndex(1)
+                .build();
+        Word word2 = Word.builder()
+                .id(11L).stage(stage).word("banana").meaning("바나나").orderIndex(2)
+                .build();
+
+        when(stageRepository.findById(1L)).thenReturn(Optional.of(stage));
+        when(stageRepository.existsById(1L)).thenReturn(true);
+        when(wordRepository.findByStageIdOrderByOrderIndexAscIdAsc(1L))
+                .thenReturn(List.of(word1, word2));
+
+        CreateStageRequest request = new CreateStageRequest();
+        request.setDifficulty(DifficultyLevel.easy);
+        request.setStageNumber(1);
+        StageWordRequest keepReq = new StageWordRequest();
+        keepReq.setWord("apple");
+        keepReq.setMeaning("사과");
+        keepReq.setOrderIndex(1);
+        request.setWords(List.of(keepReq));
+
+        stageService.updateStage(1L, request);
+
+        ArgumentCaptor<List<Word>> deleteCaptor = ArgumentCaptor.forClass(List.class);
+        verify(wordRepository).deleteAll(deleteCaptor.capture());
+        assertThat(deleteCaptor.getValue()).extracting(Word::getId).containsExactly(11L);
     }
 
     @Test


### PR DESCRIPTION
## 문제

Admin Panel에서 기존 스테이지의 단어를 수정(Edit → Save Stage)할 때 500 Internal Server Error가 발생하며 \"저장에 실패했습니다\" 토스트가 표시되는 버그.

## 원인

`replaceWords`가 기존 단어를 **전부 삭제 후 재생성**하는 방식이었기 때문에, `words` 테이블을 FK로 참조하는 테이블이 존재하면 MySQL FK 제약 위반이 발생했다.

```
words.id ←── quiz_answers.word_id
         ←── incorrect_words.word_id         ←── word_relations.word_id
         ←── word_relations.related_word_id
```

유저가 한 번이라도 퀴즈를 풀었거나 오답 기록이 생기면 위 참조가 만들어지며, 이후 Admin이 해당 스테이지의 단어를 수정하려 할 때마다 `DataIntegrityViolationException` → 500이 반환됐다.

## 수정 내용

`StageService.replaceWords`를 삭제+재생성 방식에서 **`orderIndex` 기준 in-place 업데이트**로 변경.

| | 이전 | 이후 |
|---|---|---|
| 방식 | 전체 DELETE → INSERT | 기존 Word를 `update()` 호출로 수정 |
| word ID | 매번 새로 생성 | 기존 ID 유지 |
| FK 참조 보존 | X (삭제 시 FK 위반) | O (ID 유지로 참조 무결성 보장) |
| 새 orderIndex | 신규 생성 | 동일 (builder로 INSERT) |
| 없어진 orderIndex | 해당 없음 | `deleteAll`로 개별 삭제 |

## 영향 범위

- `replaceWords`는 `updateStage`와 `upsertStage`(배치 업로드) 두 경로에서 모두 호출되며, 두 경로 모두 동일하게 수정된 로직이 적용된다.
- `deleteByStageId`(`WordRepository`)는 `deleteStage` 경로에서 여전히 사용 중이므로 제거하지 않았다.

## 테스트

- `StageServiceTest` 전체 통과 확인
- 컴파일 오류 없음